### PR TITLE
Removed always-multiline rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,16 +1,16 @@
 module.exports = {
   root: true,
   env: {
-    node: true,
+    node: true
   },
   extends: ["plugin:vue/essential", "@vue/prettier"],
   parserOptions: {
-    parser: "babel-eslint",
+    parser: "babel-eslint"
   },
   rules: {
     "no-unused-vars": "warn",
     "comma-dangle": ["error"],
     "no-console": process.env.NODE_ENV === "production" ? "error" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off",
-  },
+    "no-debugger": process.env.NODE_ENV === "production" ? "error" : "off"
+  }
 };

--- a/apollo.config.js
+++ b/apollo.config.js
@@ -5,23 +5,23 @@ const path = require("path");
 const { loadEnv } = require("vue-cli-plugin-apollo/utils/load-env");
 const env = loadEnv([
   path.resolve(__dirname, ".env"),
-  path.resolve(__dirname, ".env.local"),
+  path.resolve(__dirname, ".env.local")
 ]);
 
 module.exports = {
   client: {
     service: env.VUE_APP_APOLLO_ENGINE_SERVICE,
-    includes: ["src/**/*.{js,jsx,ts,tsx,vue,gql}"],
+    includes: ["src/**/*.{js,jsx,ts,tsx,vue,gql}"]
   },
   service: {
     name: env.VUE_APP_APOLLO_ENGINE_SERVICE,
     localSchemaFile: path.resolve(
       __dirname,
-      "./node_modules/.temp/graphql/schema.json",
-    ),
+      "./node_modules/.temp/graphql/schema.json"
+    )
   },
   engine: {
     endpoint: process.env.APOLLO_ENGINE_API_ENDPOINT,
-    apiKey: env.VUE_APP_APOLLO_ENGINE_KEY,
-  },
+    apiKey: env.VUE_APP_APOLLO_ENGINE_KEY
+  }
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: ["@vue/cli-plugin-babel/preset"],
+  presets: ["@vue/cli-plugin-babel/preset"]
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,16 +32,16 @@ export default {
     });
   },
   methods: {
-    ...mapActions({ getMaintenanceStatus: "getMaintenanceStatus" }),
+    ...mapActions({ getMaintenanceStatus: "getMaintenanceStatus" })
   },
   computed: {
     ...mapState({
-      inMaintain: "inMaintain",
-    }),
+      inMaintain: "inMaintain"
+    })
   },
   watch: {
-    $route: "getMaintenanceStatus",
-  },
+    $route: "getMaintenanceStatus"
+  }
 };
 </script>
 

--- a/src/api/forest.js
+++ b/src/api/forest.js
@@ -44,7 +44,7 @@ export function toggleDefaultCustomer(id, customer_id, val) {
   try {
     return axios.put(`forests/${id}/customers/set-default`, {
       customer_id,
-      default: val,
+      default: val
     });
   } catch (error) {}
 }
@@ -54,7 +54,7 @@ export function toggleDefaultCustomerContact(id, customer_id, contact_id, val) {
     return axios.put(`forests/${id}/customers/set-default-contact`, {
       customer_id,
       contact_id,
-      default: val,
+      default: val
     });
   } catch (error) {}
 }

--- a/src/components/AdditionButton.vue
+++ b/src/components/AdditionButton.vue
@@ -12,7 +12,7 @@ export default {
   props: {
     content: String,
     click: Function,
-    id: String,
+    id: String
   },
 
   methods: {
@@ -20,7 +20,7 @@ export default {
       if (this.click) {
         this.click();
       }
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/CustomerCreateForm.vue
+++ b/src/components/CustomerCreateForm.vue
@@ -158,12 +158,12 @@ export default {
   components: {
     ValidationObserver,
     TextInput,
-    OutlineRoundBtn,
+    OutlineRoundBtn
   },
   data() {
     return {
       shown: false,
-      form: this.initForm(),
+      form: this.initForm()
     };
   },
   methods: {
@@ -177,7 +177,7 @@ export default {
         address: "",
         phone_number: "",
         mobile_number: "",
-        email: "",
+        email: ""
       };
     },
     submit() {
@@ -185,20 +185,20 @@ export default {
         basic_contact: {
           name_kanji: {
             last_name: this.form.last_name_kanji,
-            first_name: this.form.first_name_kanji,
+            first_name: this.form.first_name_kanji
           },
           name_kana: {
             last_name: this.form.last_name_kana,
-            first_name: this.form.first_name_kana,
+            first_name: this.form.first_name_kana
           },
           address: {
-            sector: this.form.address,
+            sector: this.form.address
           },
           postal_code: this.form.postal_code,
           telephone: this.form.phone_number,
           mobilephone: this.form.mobile_number,
-          email: this.form.email,
-        },
+          email: this.form.email
+        }
       };
       this.$apollo.mutate({
         mutation: gql`
@@ -210,7 +210,7 @@ export default {
           }
         `,
         variables: {
-          input: customerInput,
+          input: customerInput
         },
         update: (store, { data: { create_customer } }) => {
           if (!create_customer.ok) {
@@ -221,9 +221,9 @@ export default {
             BusEvent.$emit("customersChanged");
             this.shown = false;
           }
-        },
+        }
       });
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/DataList.vue
+++ b/src/components/DataList.vue
@@ -21,7 +21,7 @@
       :server-items-length="serverItemsLength"
       :footer-props="{
         itemsPerPageOptions: [25, 50, 100, 250, 500, 1000],
-        itemsPerPageText: $t('raw_text.rows_per_page'),
+        itemsPerPageText: $t('raw_text.rows_per_page')
       }"
       @click:row="clickRow"
       :sort-by="sortBy"
@@ -39,7 +39,7 @@
                 item[iconRowValue] &&
                 (!iconRowValueSlice.shouldSlice ||
                   (iconRowValueSlice.shouldSlice &&
-                    iconRowValueSlice.length !== 0)),
+                    iconRowValueSlice.length !== 0))
             }"
           >
             {{
@@ -127,30 +127,30 @@ export default {
     tableRowIcon: String,
     iconRowValue: {
       type: String,
-      default: "internal_id",
+      default: "internal_id"
     },
     iconRowValueSlice: {
       type: Object,
       default: () => ({
         shouldSlice: true,
-        length: 8,
-      }),
+        length: 8
+      })
     },
     itemKey: {
       type: String,
-      default: "id",
+      default: "id"
     },
     multiSort: {
       type: Boolean,
-      default: false,
+      default: false
     },
     autoHeaders: {
       type: Boolean,
-      default: true,
+      default: true
     },
     disableSort: { type: Boolean, default: true },
     sortBy: { type: [String, Array], default: () => [] },
-    sortDesc: { type: [Boolean, Array], default: () => [] },
+    sortDesc: { type: [Boolean, Array], default: () => [] }
   },
 
   data() {
@@ -159,7 +159,7 @@ export default {
       innerOptions: {},
       tableHeight: window.innerHeight,
       isRowMouseDown: false,
-      isRowDrag: false,
+      isRowDrag: false
     };
   },
 
@@ -168,7 +168,7 @@ export default {
       return {
         未契約: "grey--lighten",
         期限切: "orange lighten-2",
-        契約済: "primary",
+        契約済: "primary"
       };
     },
     dynamicHeaders() {
@@ -187,10 +187,10 @@ export default {
         ? [
             { value: "data-table-select", width: 100, align: "center" },
             ...this.headers,
-            headerSelection,
+            headerSelection
           ]
         : [...this.headers, headerSelection];
-    },
+    }
   },
   created() {
     this.throttleRowMouseMoveHandler = throttle(this.rowMouseMoveHandler, 50);
@@ -249,7 +249,7 @@ export default {
       const innerHeight = window.innerHeight < 835 ? 835 : window.innerHeight;
       this.tableHeight =
         innerHeight - 270 <= 625 ? innerHeight : innerHeight - 270 - (56 + 16);
-    },
+    }
   },
   beforeUpdate() {
     this.unregisterMouseEventToRows();
@@ -269,7 +269,7 @@ export default {
     innerOptions: {
       handler() {
         this.$emit("update:options", this.innerOptions);
-      },
+      }
     },
 
     "innerOptions.page": {
@@ -277,15 +277,15 @@ export default {
         var table = this.$refs.dataTable;
         var wrapper = table.$el.querySelector("div.v-data-table__wrapper");
         this.$vuetify.goTo(table, { container: wrapper });
-      },
+      }
     },
 
     selected(newVal, oldVal) {
       if (newVal !== oldVal) {
         this.$emit("selectedRow", newVal);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/ErrorsCard.vue
+++ b/src/components/ErrorsCard.vue
@@ -29,8 +29,8 @@
 export default {
   props: {
     line: Number,
-    errors: Object,
-  },
+    errors: Object
+  }
 };
 </script>
 >

--- a/src/components/MainSection.vue
+++ b/src/components/MainSection.vue
@@ -19,7 +19,7 @@ import PageHeader from "./PageHeader";
 
 export default {
   name: "main-section",
-  components: { PageHeader },
+  components: { PageHeader }
 };
 </script>
 

--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -96,14 +96,24 @@
               <v-card-text v-if="selectedFeature.textTwo" class="text-center">
                 大茅: {{ selectedFeature.textOne }} -
                 {{ selectedFeature.textTwo }}
-                <v-icon color="primary" v-on:click="routeForest(selectedFeature.forestID)"> mdi-arrow-right-circle</v-icon>
-                <br>
+                <v-icon
+                  color="primary"
+                  v-on:click="routeForest(selectedFeature.forestID)"
+                >
+                  mdi-arrow-right-circle</v-icon
+                >
+                <br />
                 所有者: {{ selectedFeature.textName }}
               </v-card-text>
               <v-card-text v-else class="text-center">
                 大茅: {{ selectedFeature.textOne }}
-                <v-icon color="primary" v-on:click="routeForest(selectedFeature.forestID)"> mdi-arrow-right-circle</v-icon>
-                <br>
+                <v-icon
+                  color="primary"
+                  v-on:click="routeForest(selectedFeature.forestID)"
+                >
+                  mdi-arrow-right-circle</v-icon
+                >
+                <br />
                 所有者: {{ selectedFeature.textName }}
               </v-card-text>
             </v-card>
@@ -201,17 +211,17 @@ export default {
   props: {
     forests: {
       type: Array,
-      required: true,
+      required: true
     },
     big: {
       type: Boolean,
-      default: false,
+      default: false
     },
 
     echoedForestIdFromTable: {
       type: String,
-      default: null,
-    },
+      default: null
+    }
   },
 
   data() {
@@ -235,8 +245,8 @@ export default {
         visible: true,
         url: "https://maps.gsi.go.jp/xyz/std/{z}/{x}/{y}.png?_=20201001a",
         attributions:
-          '<a href="https://maps.gsi.go.jp/development/ichiran.html"> 国土地理院 </a>',
-      },
+          '<a href="https://maps.gsi.go.jp/development/ichiran.html"> 国土地理院 </a>'
+      }
     ];
 
     const rasterLayers = [
@@ -246,7 +256,7 @@ export default {
         visible: false,
         url: "http://localhost:8000/geoserver/raster/wms",
         layer: "raster:赤色立体図データ",
-        projection: "EPSG:4326",
+        projection: "EPSG:4326"
       },
       {
         name: "DEM",
@@ -254,7 +264,7 @@ export default {
         visible: false,
         url: "http://localhost:8000/geoserver/raster/wms",
         layer: "raster:DEMデータ",
-        projection: "EPSG:4326",
+        projection: "EPSG:4326"
       },
       {
         name: "航空写真",
@@ -262,8 +272,8 @@ export default {
         visible: false,
         url: "http://localhost:8000/geoserver/raster/wms",
         layer: "raster:航空写真データ",
-        projection: "EPSG:4326",
-      },
+        projection: "EPSG:4326"
+      }
     ];
 
     return {
@@ -280,7 +290,7 @@ export default {
       selectedFeatures,
       overlayCoordinate,
       showCard,
-      opacity,
+      opacity
     };
   },
 
@@ -332,7 +342,7 @@ export default {
 
     singleClick() {
       return singleClick;
-    },
+    }
   },
 
   watch: {
@@ -347,7 +357,7 @@ export default {
         this.loadMapFeatures().then(f => {
           this.features = f;
         });
-      },
+      }
     },
 
     echoedForestIdFromTable(val, prev) {
@@ -366,8 +376,8 @@ export default {
           stroke: new Stroke({ color: "FFF" }),
           fill: new Fill({ color: "gray" }),
           text: new Text({
-            text: filteredFeature.values_.nametag,
-          }),
+            text: filteredFeature.values_.nametag
+          })
         });
 
         filteredFeature.setStyle(style);
@@ -378,13 +388,13 @@ export default {
           stroke: new Stroke({ color: "rgb(39,78,19)", width: 2 }),
           fill: new Fill({ color: this.color }),
           text: new Text({
-            text: prevFilteredFeature.values_.nametag,
-          }),
+            text: prevFilteredFeature.values_.nametag
+          })
         });
 
         prevFilteredFeature.setStyle(unstyle);
       }
-    },
+    }
   },
 
   methods: {
@@ -404,8 +414,8 @@ export default {
         stroke: new Stroke({ color: "FFF" }),
         fill: new Fill({ color: "gray" }),
         text: new Text({
-          text: val.values_.nametag,
-        }),
+          text: val.values_.nametag
+        })
       });
       val.setStyle(style);
       this.$emit("echoSelectedFeature", val.getId());
@@ -416,8 +426,8 @@ export default {
         stroke: new Stroke({ color: "rgb(39,78,19)", width: 2 }),
         fill: new Fill({ color: this.color }),
         text: new Text({
-          text: val.values_.nametag,
-        }),
+          text: val.values_.nametag
+        })
       });
       val.setStyle(style);
       this.$emit("echoSelectedFeature", null);
@@ -430,7 +440,7 @@ export default {
         dem: "DEM",
         red: "赤色立体図",
         std: "標準地図",
-        rgb: "航空写真",
+        rgb: "航空写真"
       };
       return names[layerId];
     },
@@ -452,8 +462,8 @@ export default {
             customer: f.attributes.customer_cache,
             internal_id: f.internal_id,
             nametag: f.tags["団地"] + " " + f.internal_id,
-            land_attributes: f.land_attributes,
-          },
+            land_attributes: f.land_attributes
+          }
         };
       });
 
@@ -467,7 +477,7 @@ export default {
       xhr.open("GET", src);
       xhr.setRequestHeader(
         "Authorization",
-        "Bearer " + localStorage.getItem("accessToken"),
+        "Bearer " + localStorage.getItem("accessToken")
       );
       xhr.responseType = "arraybuffer";
       xhr.onload = function() {
@@ -518,15 +528,15 @@ export default {
           {
             INFO_FORMAT: "application/json",
             feature_count: 1,
-            query_layers: "crm_Forests",
-          },
+            query_layers: "crm_Forests"
+          }
         );
         this.overlayCoordinate = event.coordinate;
 
         let featureRequest = await this.$rest(loggedURL);
         if (featureRequest.numberReturned > 0) {
           this.selectedFeature = this.returnPopupText(
-            featureRequest.features[0],
+            featureRequest.features[0]
           );
           this.showCard = true;
         } else {
@@ -535,8 +545,8 @@ export default {
       }
     },
 
-    pointOnSurface: findPointOnSurface,
-  },
+    pointOnSurface: findPointOnSurface
+  }
 };
 </script>
 

--- a/src/components/OutlineRoundBtn.vue
+++ b/src/components/OutlineRoundBtn.vue
@@ -20,7 +20,7 @@ export default {
     on: Object,
     icon: String,
     content: String,
-    loading: Boolean,
-  },
+    loading: Boolean
+  }
 };
 </script>

--- a/src/components/PageHeader.vue
+++ b/src/components/PageHeader.vue
@@ -112,14 +112,14 @@
                 <div
                   class="white--text page-header__detail__data"
                   :class="{
-                    'default-height': isDetail,
+                    'default-height': isDetail
                   }"
                 >
                   <p
                     class="text-truncate page-header__detail__data__title font-weight-bold"
                     :class="{
                       'mb-2': !headerInfo.desc,
-                      'mb-0': !!headerInfo.desc,
+                      'mb-0': !!headerInfo.desc
                     }"
                   >
                     {{ headerInfo.title }}
@@ -172,7 +172,7 @@ export default {
 
   data() {
     return {
-      user: null,
+      user: null
     };
   },
   methods: {
@@ -188,7 +188,7 @@ export default {
       } catch {
         this.user = null;
       }
-    },
+    }
   },
 
   computed: {
@@ -225,14 +225,14 @@ export default {
         this.$store.state.backBtnContent &&
         this.$store.state.backBtnContent.length > 0
       );
-    },
+    }
   },
 
   created() {
     this.getUserInfo();
     busEvent.$off("profile:refresh");
     busEvent.$on("profile:refresh", () => this.getUserInfo());
-  },
+  }
 };
 </script>
 

--- a/src/components/RangeDatePicker.vue
+++ b/src/components/RangeDatePicker.vue
@@ -66,26 +66,26 @@ extend("daterange", {
       (result.length === 2 && result[0] < result[1]) || result.length === 1
     );
   },
-  message: i18n.t("validations.daterange"),
+  message: i18n.t("validations.daterange")
 });
 
 export default {
   name: "range-date-picker",
 
   components: {
-    ValidationProvider,
+    ValidationProvider
   },
 
   props: {
     label: String,
-    dates: Array,
+    dates: Array
   },
 
   data() {
     return {
       menu: false,
       innerDates: this.dates,
-      innerDateRange: this.dates.join(dateSeparator),
+      innerDateRange: this.dates.join(dateSeparator)
     };
   },
 
@@ -108,7 +108,7 @@ export default {
         .filter(d => isValid(d))
         .map(d => format(d, "yyyy-MM-dd"));
       this.innerDates = parts;
-    },
+    }
   },
 
   computed: {
@@ -128,7 +128,7 @@ export default {
         (parts.length === 2 && parts[0] < parts[1]) ||
         parts.length === 1
       );
-    },
+    }
   },
   watch: {
     innerDateRange() {
@@ -141,15 +141,15 @@ export default {
       deep: true,
       handler(val) {
         this.$emit("newDates", val);
-      },
+      }
     },
     menu() {
       if (this.menu === false) {
         this.rangeToInnerDate();
         this.$refs.menu.save(this.innerDates);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/SearchCard.vue
+++ b/src/components/SearchCard.vue
@@ -49,7 +49,7 @@
         <div
           class="d-flex align-center"
           :class="{
-            'show-add-criteria': conditions.length === searchCriteria.length,
+            'show-add-criteria': conditions.length === searchCriteria.length
           }"
           @click="addSearchField"
         >
@@ -83,12 +83,12 @@ export default {
   name: "search-card",
 
   components: {
-    SelectList,
+    SelectList
   },
 
   props: {
     searchCriteria: Array,
-    onSearch: Function,
+    onSearch: Function
   },
 
   data() {
@@ -99,9 +99,9 @@ export default {
         {
           fields: [...this.searchCriteria],
           criteria: null,
-          keyword: null,
-        },
-      ],
+          keyword: null
+        }
+      ]
     };
   },
   computed: {
@@ -118,7 +118,7 @@ export default {
       }
 
       return true;
-    },
+    }
   },
   watch: {
     searchCriteria(val) {
@@ -131,11 +131,11 @@ export default {
           con,
           "fields",
           this.searchCriteria.filter(
-            f => !val.has(f.value) || f.value === con.criteria,
-          ),
+            f => !val.has(f.value) || f.value === con.criteria
+          )
         );
       }
-    },
+    }
   },
   methods: {
     resetSearch() {
@@ -143,8 +143,8 @@ export default {
         {
           fields: [...this.originalSearchCriteria],
           criteria: null,
-          keyword: null,
-        },
+          keyword: null
+        }
       ];
       this.usedFields = new Set();
 
@@ -162,9 +162,7 @@ export default {
         this.conditions.push({
           keyword: null,
           criteria: null,
-          fields: this.searchCriteria.filter(
-            f => !this.usedFields.has(f.value),
-          ),
+          fields: this.searchCriteria.filter(f => !this.usedFields.has(f.value))
         });
       }
     },
@@ -189,8 +187,8 @@ export default {
       } else {
         this.$emit("unableDelete", true);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/SectionContainerWrapper.vue
+++ b/src/components/SectionContainerWrapper.vue
@@ -37,7 +37,7 @@ export default {
   components: {
     ContentHeader,
     AdditionButton,
-    UpdateButton,
+    UpdateButton
   },
   props: {
     headerContent: String,
@@ -52,7 +52,7 @@ export default {
     isEditing: Boolean,
     cancelEdit: Function,
     showAddBtn: { type: Boolean, default: true },
-    displayAdditionBtn: { type: Boolean, default: true },
-  },
+    displayAdditionBtn: { type: Boolean, default: true }
+  }
 };
 </script>

--- a/src/components/SelectList.vue
+++ b/src/components/SelectList.vue
@@ -21,12 +21,12 @@ export default {
     placeHolder: String,
     index: Number,
     value: String,
-    hideDetails: { type: Boolean, default: false },
+    hideDetails: { type: Boolean, default: false }
   },
 
   data() {
     return {
-      innerValue: this.value,
+      innerValue: this.value
     };
   },
 
@@ -58,12 +58,12 @@ export default {
       } else {
         input.style.width = "auto";
       }
-    },
+    }
   },
   computed: {
     hasSelectedValue() {
       return this.innerValue || this.innerValue === 0;
-    },
+    }
   },
   watch: {
     innerValue() {
@@ -73,8 +73,8 @@ export default {
     },
     value() {
       this.innerValue = this.value;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/SelectListModal.vue
+++ b/src/components/SelectListModal.vue
@@ -54,12 +54,12 @@ export default {
     "loading",
     "handleSubmitClick",
     "disableAdditionBtn",
-    "handleCancelClick",
+    "handleCancelClick"
   ],
   data() {
     return {
       shown_: false,
-      keyword: "",
+      keyword: ""
     };
   },
   mounted() {
@@ -73,7 +73,7 @@ export default {
       if (val != this.shown) {
         this.$emit("update:shown", val);
       }
-    },
+    }
   },
   methods: {
     onCancel() {
@@ -89,19 +89,19 @@ export default {
       if (el.scrollHeight - el.scrollTop < (el.clientHeight * 4) / 3) {
         this.$emit("needToLoad");
       }
-    },
+    }
   },
   computed: {
     isSearchEmpty() {
       return this.keyword === "";
-    },
+    }
   },
   beforeDestroy() {
     this.$refs.listContent.removeEventListener(
       "scroll",
-      this.needLoadOnNearEnd,
+      this.needLoadOnNearEnd
     );
-  },
+  }
 };
 </script>
 

--- a/src/components/SingleDatePicker.vue
+++ b/src/components/SingleDatePicker.vue
@@ -41,7 +41,7 @@ import { ValidationProvider } from "vee-validate";
 export default {
   name: "single-date-picker",
   components: {
-    ValidationProvider,
+    ValidationProvider
   },
 
   props: {
@@ -49,13 +49,13 @@ export default {
     label: String,
     date: String,
     readonly: { type: Boolean, default: true },
-    rules: String,
+    rules: String
   },
 
   data() {
     return {
       menu: false,
-      innerDate: this.date,
+      innerDate: this.date
     };
   },
 
@@ -63,8 +63,8 @@ export default {
     save() {
       this.$refs.menu.save(this.innerDate);
       this.$emit("newDate", this.innerDate);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/SnackBar.vue
+++ b/src/components/SnackBar.vue
@@ -19,7 +19,7 @@ export default {
     isShow: Boolean,
     msg: String,
     color: String,
-    timeout: Number,
+    timeout: Number
   },
 
   methods: {
@@ -29,7 +29,7 @@ export default {
 
     onDismiss(val) {
       this.$emit("dismiss", val);
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/TableAction.vue
+++ b/src/components/TableAction.vue
@@ -22,19 +22,19 @@ export default {
   name: "table-action",
 
   components: {
-    SelectList,
+    SelectList
   },
 
   props: {
     selectedCount: Number,
-    actions: Array,
+    actions: Array
   },
 
   methods: {
     onSelected(val) {
       this.$emit("selected-action", val);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/TimePicker.vue
+++ b/src/components/TimePicker.vue
@@ -37,14 +37,14 @@ export default {
 
   props: {
     label: String,
-    time: String,
+    time: String
   },
 
   data() {
     return {
       menu: false,
       innerTime: this.time,
-      rules: [val => !!val || `${this.label}は必須項目です`],
+      rules: [val => !!val || `${this.label}は必須項目です`]
     };
   },
 
@@ -52,8 +52,8 @@ export default {
     save() {
       this.$refs.menu.save(this.innerTime);
       this.$emit("newTime", this.innerTime);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ActionLog.vue
+++ b/src/components/detail/ActionLog.vue
@@ -30,12 +30,12 @@ export default {
   props: {
     appName: { type: String },
     objectType: { type: String },
-    objectId: { type: String },
+    objectId: { type: String }
   },
   data() {
     return {
       isLoading: false,
-      results: [],
+      results: []
     };
   },
   created() {
@@ -52,7 +52,7 @@ export default {
 
         this.isLoading = true;
         const response = await this.$rest.get(
-          `/activity/ja_JP/${this.appName}/${this.objectType}/${this.objectId}`,
+          `/activity/ja_JP/${this.appName}/${this.objectType}/${this.objectId}`
         );
         if (response) {
           this.results = response.results;
@@ -63,8 +63,8 @@ export default {
           this.isLoading = false;
         }, 400);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss" scoped>

--- a/src/components/detail/ArchiveBasicInfo.vue
+++ b/src/components/detail/ArchiveBasicInfo.vue
@@ -105,20 +105,20 @@ export default {
     ArchiveParticipantCard,
     SingleDatePicker,
     TimePicker,
-    ValidationObserver,
+    ValidationObserver
   },
 
   props: {
     info: Object,
     isUpdate: Boolean,
     isSave: Boolean,
-    isDetail: Boolean,
+    isDetail: Boolean
   },
 
   data() {
     return {
       innerDate: "",
-      innerTime: "",
+      innerTime: ""
     };
   },
 
@@ -145,7 +145,7 @@ export default {
 
     datetimePickerInvalid() {
       return !this.date || !this.time;
-    },
+    }
   },
 
   watch: {
@@ -154,7 +154,7 @@ export default {
       async handler() {
         const isValid = await this.$refs.observer.validate();
         this.$emit("archive:save-disable", !isValid);
-      },
+      }
     },
 
     innerDate(val) {
@@ -177,8 +177,8 @@ export default {
         this.info.archive_date = `${date} ${time}`;
         this.$emit("archive:update-basic-info", this.info);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ArchiveBasicInfoContainer.vue
+++ b/src/components/detail/ArchiveBasicInfoContainer.vue
@@ -57,15 +57,15 @@ export default {
   components: {
     ContentHeader,
     ArchiveBasicInfo,
-    UpdateButton,
+    UpdateButton
   },
 
   props: {
     isDetail: {
       type: Boolean,
-      default: true,
+      default: true
     },
-    id: String,
+    id: String
   },
 
   data() {
@@ -77,7 +77,7 @@ export default {
       updateLoading: false,
       saveDisabled: false,
       info: {},
-      immutableInfo: {},
+      immutableInfo: {}
     };
   },
 
@@ -111,7 +111,7 @@ export default {
         content: basicInfo.content,
         title: basicInfo.title,
         attributes: basicInfo.attributes,
-        tags: basicInfo.tags,
+        tags: basicInfo.tags
       };
     },
 
@@ -161,10 +161,10 @@ export default {
             this.isSave = false;
           });
       }
-    },
+    }
   },
   watch: {
-    $route: "fetchBasicInfo",
-  },
+    $route: "fetchBasicInfo"
+  }
 };
 </script>

--- a/src/components/detail/ArchiveDetailMixin.js
+++ b/src/components/detail/ArchiveDetailMixin.js
@@ -1,5 +1,5 @@
 export default {
   props: {
-    allowEdit: { type: Boolean },
-  },
+    allowEdit: { type: Boolean }
+  }
 };

--- a/src/components/detail/ArchiveDocumentContainer.vue
+++ b/src/components/detail/ArchiveDocumentContainer.vue
@@ -112,7 +112,7 @@ export default {
     ContentHeader,
     DocumentCard,
     UpdateButton,
-    AdditionButton,
+    AdditionButton
   },
 
   data() {
@@ -129,7 +129,7 @@ export default {
       duplicateUploadFiles: [],
       invalidUploadFilesExtension: [],
       acceptFileExtensions:
-        ".xlsx, .xls, .csv, .doc, .docx, .pdf, .zip, .png, .jpg, .gif, .bmp, .tif, .txt",
+        ".xlsx, .xls, .csv, .doc, .docx, .pdf, .zip, .png, .jpg, .gif, .bmp, .tif, .txt"
     };
   },
 
@@ -187,7 +187,7 @@ export default {
       return intersectionWith(
         files1,
         files2,
-        (f1, f2) => (f1.attributes?.original_file_name || f1.name) === f2.name,
+        (f1, f2) => (f1.attributes?.original_file_name || f1.name) === f2.name
       );
     },
 
@@ -218,11 +218,11 @@ export default {
       const originalDocs = [...this.documents, ...validFiles];
       this.duplicateUploadFiles = this.getDuplicateFiles(
         this.documents,
-        validFiles,
+        validFiles
       );
       const filteredDocs = this.removeDuplicateFiles(
         this.documents,
-        validFiles,
+        validFiles
       );
       if (
         originalDocs.length !== filteredDocs.length ||
@@ -252,13 +252,13 @@ export default {
         if (newDocs.length > 0) {
           const newDocuments = await this.$rest.post(
             `archives/${this.id}/attachments`,
-            data,
+            data
           );
           if (newDocuments) {
             this.documents.splice(
               this.documents.length - 1 - (newDocs.length - 1),
               newDocs.length,
-              ...newDocuments.data,
+              ...newDocuments.data
             );
           }
         }
@@ -277,7 +277,7 @@ export default {
     handleUndoDelete(doc, index) {
       this.$set(doc, "deleted", false);
       this.deleteDocuments.splice(index, 1);
-    },
+    }
   },
 
   computed: {
@@ -285,7 +285,7 @@ export default {
       return (
         this.documents.filter(doc => doc.added || doc.deleted).length === 0
       );
-    },
+    }
   },
 
   watch: {
@@ -295,8 +295,8 @@ export default {
         this.invalidUploadFilesExtension = [];
         this.$refs.fileInput.value = "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ArchiveOtherRelatedUsersContainer.vue
+++ b/src/components/detail/ArchiveOtherRelatedUsersContainer.vue
@@ -44,17 +44,17 @@ export default {
   components: {
     ContentHeader,
     UpdateButton,
-    TextInput,
+    TextInput
   },
   props: {
-    archive: { type: Object },
+    archive: { type: Object }
   },
   data() {
     return {
       loading: false,
       archive_id: this.$route.params.id,
       tempParticipants: [],
-      participants: [],
+      participants: []
     };
   },
 
@@ -69,13 +69,13 @@ export default {
       this.loading = true;
       try {
         await this.$rest.put(`archives/${this.archive_id}/other-participants`, {
-          other_participants: this.tempParticipants,
+          other_participants: this.tempParticipants
         });
         this.participants = this.tempParticipants;
         this.isEditing = false;
       } catch (error) {}
       this.loading = false;
-    },
+    }
   },
 
   computed: {
@@ -85,11 +85,11 @@ export default {
       },
       set(val) {
         this.tempParticipants = reject(val.split(","), isEmpty);
-      },
+      }
     },
     saveDisabled() {
       return this.participantsText === this.participants.join(",");
-    },
+    }
   },
 
   watch: {
@@ -103,8 +103,8 @@ export default {
         ? this.archive.attributes.other_participants || []
         : [];
       this.tempParticipants = [...this.participants];
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ArchiveParticipantCard.vue
+++ b/src/components/detail/ArchiveParticipantCard.vue
@@ -8,7 +8,7 @@
       flat: flat,
       deleted: deleted,
       added: added,
-      'show-pointer': showPointer,
+      'show-pointer': showPointer
     }"
     @click="$emit('selected', card_id, index)"
   >
@@ -66,13 +66,13 @@ export default {
     deleted: { type: Boolean, default: false },
     added: { type: Boolean, default: false },
     index: Number,
-    showPointer: { type: Boolean, default: false },
+    showPointer: { type: Boolean, default: false }
   },
 
   methods: {
     onNavigation() {
       this.$router.push(`/users/${this.card_id}`);
-    },
+    }
   },
 
   computed: {
@@ -81,8 +81,8 @@ export default {
     },
     hasPermission() {
       return hasScope("admin") || hasScope("group_admin");
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ArchiveParticipantContainer.vue
+++ b/src/components/detail/ArchiveParticipantContainer.vue
@@ -103,11 +103,11 @@ export default {
     AdditionButton,
     SelectListModal,
     CustomerContactList,
-    CustomerContactCard,
+    CustomerContactCard
   },
   props: {
     id: { type: String },
-    participants: { type: Array, default: () => [] },
+    participants: { type: Array, default: () => [] }
   },
   data() {
     return {
@@ -116,7 +116,7 @@ export default {
       selectingContactId: null,
       selectingCustomerId: null,
       customerIdNameMap: {},
-      itemsForAddingUrl: "/customercontacts",
+      itemsForAddingUrl: "/customercontacts"
     };
   },
   computed: {
@@ -131,20 +131,20 @@ export default {
     contactsToAddData() {
       return this.contactsToAdd.map(c => ({
         contact_id: c.id,
-        customer_id: c.customer_id,
+        customer_id: c.customer_id
       }));
     },
     contactsToDeleteData() {
       return this.contactsToDelete.map(c => ({
         contact_id: c.id,
-        customer_id: c.customer_id,
+        customer_id: c.customer_id
       }));
     },
     contactIdsMap() {
       return Object.fromEntries(
-        this.tempParticipants.map(c => [`${c.id},${c.customer_id}`, true]),
+        this.tempParticipants.map(c => [`${c.id},${c.customer_id}`, true])
       );
-    },
+    }
   },
   methods: {
     renderCustomerName(item) {
@@ -173,7 +173,7 @@ export default {
         this.saving = true;
         await this.$rest.put(`/archives/${this.id}/customers`, {
           added: this.contactsToAddData,
-          deleted: this.contactsToDeleteData,
+          deleted: this.contactsToDeleteData
         });
         this.$emit("saved");
         this.saving = false;
@@ -187,12 +187,12 @@ export default {
     async handleAdd() {
       const item = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       this.$set(
         this.customerIdNameMap,
         item.customer_id,
-        item.customer_name_kanji,
+        item.customer_name_kanji
       );
       item.added = true;
       if (this.selectingCustomerId) {
@@ -211,7 +211,7 @@ export default {
         delete contact.added;
         this.contactsToAdd = reject(this.contactsToAdd, {
           id: contact.id,
-          customer_id: contact.customer_id,
+          customer_id: contact.customer_id
         });
         this.itemsForAdding = { results: [] };
       } else {
@@ -223,9 +223,9 @@ export default {
       this.$set(contact, "deleted", undefined);
       this.contactsToDelete = reject(this.contactsToDelete, {
         id: contact.id,
-        customer_id: contact.customer_id,
+        customer_id: contact.customer_id
       });
-    },
+    }
   },
   watch: {
     isEditing(val) {
@@ -249,7 +249,7 @@ export default {
         customerIdNameMap[c.customer_id] = c.customer_name_kanji;
       }
       this.customerIdNameMap = customerIdNameMap;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/ArchiveParticipantList.vue
+++ b/src/components/detail/ArchiveParticipantList.vue
@@ -23,12 +23,12 @@ export default {
   name: "archive-participant-list",
 
   components: {
-    ArchiveParticipantCard,
+    ArchiveParticipantCard
   },
 
   props: {
     participants: Array,
-    isUpdate: Boolean,
-  },
+    isUpdate: Boolean
+  }
 };
 </script>

--- a/src/components/detail/ArchiveRelatedForestContainer.vue
+++ b/src/components/detail/ArchiveRelatedForestContainer.vue
@@ -95,7 +95,7 @@ export default {
     UpdateButton,
     AdditionButton,
     SelectListModal,
-    ForestInfoCard,
+    ForestInfoCard
   },
 
   data() {
@@ -114,7 +114,7 @@ export default {
       selectingForestIndex: null,
       addRelatedForestLoading: false,
       searchNext: null,
-      showNotFoundMsg: false,
+      showNotFoundMsg: false
     };
   },
 
@@ -170,14 +170,14 @@ export default {
         const isDeleted = await this.$rest.delete(
           `/archives/${this.id}/forests`,
           {
-            data: deleteRequest,
-          },
+            data: deleteRequest
+          }
         );
         if (isDeleted) {
           this.selectingForestId = null;
           this.relatedForests = this.removeDuplicateForests(
             this.relatedForests,
-            this.deletedForests,
+            this.deletedForests
           );
           const pureForests = cloneDeep(this.deletedForests);
           pureForests.forEach(f => (f.deleted = false));
@@ -193,16 +193,16 @@ export default {
         const addRequest = { ids: addedIds };
         const newRelatedForests = await this.$rest.post(
           `/archives/${this.id}/forests`,
-          addRequest,
+          addRequest
         );
         if (newRelatedForests) {
           const tempForest = this.removeDuplicateForests(
             this.relatedForests,
-            newRelatedForests.data,
+            newRelatedForests.data
           );
           this.allForests = this.removeDuplicateForests(
             this.allForests,
-            this.addedForests,
+            this.addedForests
           );
           this.immutableAllForest = cloneDeep(this.allForests);
           tempForest.push(...newRelatedForests.data);
@@ -231,17 +231,17 @@ export default {
       if (this.next !== null) {
         this.fetchAllForestLoading = true;
         const response = await this.$rest.get(
-          next !== "" ? next : "/forests/minimal",
+          next !== "" ? next : "/forests/minimal"
         );
         if (response) {
           this.fetchAllForestLoading = false;
           const filteredForests = this.removeDuplicateForests(
             response.results,
-            this.relatedForests,
+            this.relatedForests
           );
           const allForests = this.removeDuplicateForests(
             filteredForests,
-            this.allForests,
+            this.allForests
           );
           this.allForests.push(...allForests);
           this.immutableAllForest.push(...allForests);
@@ -291,8 +291,8 @@ export default {
       this.fetchAllForestLoading = true;
       const response = await this.$rest.get("/forests/minimal", {
         params: {
-          search: keyword || "",
-        },
+          search: keyword || ""
+        }
       });
       if (response) {
         this.showNotFoundMsg =
@@ -301,14 +301,14 @@ export default {
         this.immutableAllForest = [];
         const tempSearchData = this.removeDuplicateForests(
           response.results,
-          this.relatedForests,
+          this.relatedForests
         );
         this.next = response.next;
         this.allForests.push(...tempSearchData);
         this.immutableAllForest.push(...tempSearchData);
         this.fetchAllForestLoading = false;
       }
-    },
+    }
   },
 
   computed: {
@@ -318,7 +318,7 @@ export default {
 
     deletedForests() {
       return this.relatedForests.filter(forest => forest.deleted);
-    },
+    }
   },
 
   watch: {
@@ -334,8 +334,8 @@ export default {
         if (allForests.length <= 3 && this.next !== null) {
           this.handleLoadMore();
         }
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>

--- a/src/components/detail/ArchiveRelatedUserContainer.vue
+++ b/src/components/detail/ArchiveRelatedUserContainer.vue
@@ -94,7 +94,7 @@ export default {
     UpdateButton,
     AdditionButton,
     SelectListModal,
-    ArchiveParticipantCard,
+    ArchiveParticipantCard
   },
 
   data() {
@@ -104,7 +104,7 @@ export default {
       addedParticipants: [],
       deletedParticipants: [],
       itemsForAddingUrl: "/users/minimal",
-      isLoading_: false,
+      isLoading_: false
     };
   },
 
@@ -138,9 +138,9 @@ export default {
           `/archives/${this.archive_id}/users`,
           {
             data: {
-              ids: deletedIds,
-            },
-          },
+              ids: deletedIds
+            }
+          }
         );
         if (isDeleted) {
           this.modalSelectingId = null;
@@ -153,7 +153,7 @@ export default {
         const addedIds = this.addedParticipants.map(p => p.id);
         const newParticipants = await this.$rest.post(
           `/archives/${this.archive_id}/users`,
-          { ids: addedIds },
+          { ids: addedIds }
         );
         if (newParticipants) {
         }
@@ -182,7 +182,7 @@ export default {
     submitRelatedParticipant() {
       const participant = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       participant.added = true;
       this.addedParticipants.push(participant);
@@ -196,7 +196,7 @@ export default {
       if (participant.added) {
         delete participant.added;
         this.addedParticipants = reject(this.addedParticipants, {
-          id: participant.id,
+          id: participant.id
         });
         this.itemsForAdding = { results: [] };
       } else {
@@ -207,9 +207,9 @@ export default {
     handleUndoDelete(participant) {
       this.$set(participant, "deleted", undefined);
       this.deletedParticipants = reject(this.deletedParticipants, {
-        id: participant.id,
+        id: participant.id
       });
-    },
+    }
   },
 
   computed: {
@@ -218,7 +218,7 @@ export default {
     },
     userIdsMap() {
       return Object.fromEntries(
-        this.tempUserParticipants.map(u => [u.id, true]),
+        this.tempUserParticipants.map(u => [u.id, true])
       );
     },
     saveDisabled() {
@@ -226,7 +226,7 @@ export default {
         this.addedParticipants.length === 0 &&
         this.deletedParticipants.length === 0
       );
-    },
+    }
   },
 
   watch: {
@@ -244,8 +244,8 @@ export default {
           this.itemsForAdding = { results: [] };
         }
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/AttachmentCard.vue
+++ b/src/components/detail/AttachmentCard.vue
@@ -58,12 +58,12 @@ export default {
     cancel: Function,
     ripple: {
       type: Boolean,
-      default: true,
+      default: true
     },
     routeName: {
       type: String,
-      default: "archive-detail",
-    },
+      default: "archive-detail"
+    }
   },
 
   methods: {
@@ -92,13 +92,13 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
       }
       return "";
-    },
+    }
   },
 
   computed: {
@@ -108,8 +108,8 @@ export default {
       } else {
         return "mdi-chevron-right";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/AttachmentContainer.vue
+++ b/src/components/detail/AttachmentContainer.vue
@@ -45,20 +45,20 @@ export default {
 
   components: {
     ContentHeader,
-    AttachmentCard,
+    AttachmentCard
   },
 
   props: {
     id: String,
     archives: { type: Array, default: () => [] },
-    routeName: { type: String, default: "archive-detail" },
+    routeName: { type: String, default: "archive-detail" }
   },
 
   data() {
     return {
       loading: false,
       isExpand: false,
-      isUpdate: false,
+      isUpdate: false
     };
   },
   computed: {
@@ -72,8 +72,8 @@ export default {
 
     isRequiredExpand() {
       return this.archives.length > 3;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/BankingInfoContainer.vue
+++ b/src/components/detail/BankingInfoContainer.vue
@@ -31,17 +31,17 @@ export default {
   components: {
     ContentHeader,
     BasicInfo,
-    UpdateButton,
+    UpdateButton
   },
 
   props: {
-    info: Array,
+    info: Array
   },
 
   data() {
     return {
-      isUpdate: false,
+      isUpdate: false
     };
-  },
+  }
 };
 </script>

--- a/src/components/detail/BasicInfo.vue
+++ b/src/components/detail/BasicInfo.vue
@@ -15,13 +15,13 @@ export default {
   name: "basic-info",
 
   components: {
-    TextInfo,
+    TextInfo
   },
 
   props: {
     isUpdate: Boolean,
     isSave: Boolean,
-    infos: Array,
+    infos: Array
   },
 
   watch: {
@@ -31,7 +31,7 @@ export default {
           this.$emit("updateInfo", this.infos);
         }
       }
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/BasicInfoContainer.vue
+++ b/src/components/detail/BasicInfoContainer.vue
@@ -30,18 +30,18 @@ export default {
 
   components: {
     ContentHeader,
-    BasicInfo,
+    BasicInfo
   },
   props: {
     businessId: String,
     id: String,
     info: Array,
-    displayAdditionBtn: { type: Boolean, default: true },
+    displayAdditionBtn: { type: Boolean, default: true }
   },
   data() {
     return {
       isUpdate: false,
-      isSave: false,
+      isSave: false
     };
   },
 
@@ -52,7 +52,7 @@ export default {
 
     handleToggleEdit() {
       this.isUpdate = !this.isUpdate;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/ContactTab.vue
+++ b/src/components/detail/ContactTab.vue
@@ -74,12 +74,12 @@ export default {
   name: "contact-tab",
 
   components: {
-    CustomerContactList,
+    CustomerContactList
   },
 
   data() {
     return {
-      selectedTab: "owner",
+      selectedTab: "owner"
     };
   },
 
@@ -88,7 +88,7 @@ export default {
     customersContacts: Array,
     isEditing: Boolean,
     selectingCustomerId: String,
-    customerIdNameMap: Object,
+    customerIdNameMap: Object
   },
 
   methods: {
@@ -98,7 +98,7 @@ export default {
 
     contactorTabClick() {
       this.selectedTab = "contactor";
-    },
+    }
   },
 
   computed: {
@@ -108,8 +108,8 @@ export default {
 
     representativeNote() {
       return this.selectedTab === "owner" ? "代表連絡者" : "主要連絡者";
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ContainerMixin.js
+++ b/src/components/detail/ContainerMixin.js
@@ -3,17 +3,17 @@ export default {
     isLoading: Boolean,
     headerContent: String,
     toggleEditBtnContent: String,
-    addBtnContent: String,
+    addBtnContent: String
   },
   data() {
     return {
       isEditing: false,
-      saving: false,
+      saving: false
     };
   },
   methods: {
     cancel() {
       this.isEditing = false;
-    },
-  },
+    }
+  }
 };

--- a/src/components/detail/ContentHeader.vue
+++ b/src/components/detail/ContentHeader.vue
@@ -38,7 +38,7 @@ export default {
   name: "content-header",
 
   components: {
-    AdditionButton,
+    AdditionButton
   },
 
   props: {
@@ -47,16 +47,16 @@ export default {
     toggleEditBtnContent: String,
     displayAdditionBtn: {
       type: Boolean,
-      default: true,
+      default: true
     },
-    permissions: Array,
+    permissions: Array
   },
 
   methods: {
     enableEdit() {
       this.$emit("toggleEdit", true);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/CustomerContactCard.vue
+++ b/src/components/detail/CustomerContactCard.vue
@@ -115,7 +115,7 @@
         owner: isOwner,
         contactor: isContactor,
         default: this.contact.default,
-        pointer: this.isUpdate,
+        pointer: this.isUpdate
       }"
       @click.stop="onTagClick"
     ></div>
@@ -142,7 +142,7 @@ export default {
     customerName: String,
     showDefaultBadge: { type: Boolean, default: false },
     clickable: { type: Boolean, default: false },
-    allowDelete: { type: Boolean, default: true },
+    allowDelete: { type: Boolean, default: true }
   },
 
   data() {
@@ -157,8 +157,8 @@ export default {
         "孫",
         "友人",
         "その他親族",
-        "その他",
-      ],
+        "その他"
+      ]
     };
   },
 
@@ -172,9 +172,9 @@ export default {
           "toggleContactDefault",
           !this.contact.default,
           this.contact.customer_id,
-          this.contact.id,
+          this.contact.id
         );
-    },
+    }
   },
 
   computed: {
@@ -232,8 +232,8 @@ export default {
     },
     relationshipType() {
       return this.contact.cc_attrs?.relationship_type || "本人";
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/CustomerContactList.vue
+++ b/src/components/detail/CustomerContactList.vue
@@ -40,7 +40,7 @@ export default {
   name: "customer-contact-list",
 
   components: {
-    CustomerContactCard,
+    CustomerContactCard
   },
 
   props: {
@@ -54,7 +54,7 @@ export default {
     customerIdNameMap: Object,
     mode: String,
     showDefaultBadge: { type: Boolean, default: false },
-    allowDelete: { type: Boolean, default: true },
+    allowDelete: { type: Boolean, default: true }
   },
   methods: {
     getCustomerName(customer_id) {
@@ -71,7 +71,7 @@ export default {
     },
     handleRelationshipChange(contact_id, val) {
       this.$emit("relationshipChange", contact_id, val);
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/CustomerContactsContainer.vue
+++ b/src/components/detail/CustomerContactsContainer.vue
@@ -64,7 +64,7 @@ export default {
   components: {
     SectionContainerWrapper,
     CustomerContactList,
-    ContactForm,
+    ContactForm
   },
 
   props: {
@@ -72,7 +72,7 @@ export default {
     permissions: Array,
     id: String,
     contactIdNameMap: Object,
-    contactType: String,
+    contactType: String
   },
   data() {
     return {
@@ -83,7 +83,7 @@ export default {
       form: this.initForm(),
       formErrors: {},
       relationshipChanges: [],
-      contacts_: [],
+      contacts_: []
     };
   },
   computed: {
@@ -101,12 +101,12 @@ export default {
     },
     contactsAddData() {
       return reject(this.relationshipChanges, i =>
-        this.contactIdsToDelete.includes(i.contact),
+        this.contactIdsToDelete.includes(i.contact)
       ).map(i => ({
         contact: i.contact,
-        relationship_type: i.val,
+        relationship_type: i.val
       }));
-    },
+    }
   },
   methods: {
     handleCancelEdit() {
@@ -116,7 +116,7 @@ export default {
     },
     handleRelationshipChange(contact_id, val) {
       const others = reject(this.relationshipChanges, {
-        contact: contact_id,
+        contact: contact_id
       });
       const contact = find(this.contacts, { id: contact_id });
       if (contact.cc_attrs.relationship_type === val) {
@@ -144,7 +144,7 @@ export default {
         await this.$rest.put(`/customers/${this.id}/contacts`, {
           adding: this.contactsAddData,
           deleting: this.contactIdsToDelete,
-          contact_type: this.contactType,
+          contact_type: this.contactType
         });
         this.$emit("saved");
         this.saving = false;
@@ -154,7 +154,7 @@ export default {
         this.saving = false;
         if (error.response && error.response.status === 400) {
           this.$dialog.notify.error(
-            this.$t("messages.record_updated_before_please_reload_first"),
+            this.$t("messages.record_updated_before_please_reload_first")
           );
         }
       }
@@ -171,29 +171,29 @@ export default {
         municipality: "",
         telephone: "",
         mobilephone: "",
-        email: "",
+        email: ""
       };
     },
     async handleAdd() {
       const data = {
         name_kanji: {
           last_name: this.form.last_name_kanji,
-          first_name: this.form.first_name_kanji,
+          first_name: this.form.first_name_kanji
         },
         name_kana: {
           last_name: this.form.last_name_kana,
-          first_name: this.form.first_name_kana,
+          first_name: this.form.first_name_kana
         },
         address: {
           sector: this.form.sector,
           prefecture: this.form.prefecture,
-          municipality: this.form.municipality,
+          municipality: this.form.municipality
         },
         postal_code: this.form.postal_code,
         telephone: this.form.telephone,
         mobilephone: this.form.mobilephone,
         email: this.form.email,
-        contact_type: this.contactType,
+        contact_type: this.contactType
       };
       try {
         await this.$rest.post(`/customers/${this.id}/contacts`, data);
@@ -204,14 +204,14 @@ export default {
         if (error.response && error.response.status < 500)
           this.formErrors = error.response.data.errors;
       }
-    },
+    }
   },
   watch: {
     contacts: {
       deep: true,
       handler(val) {
         this.contacts_ = cloneDeep(val);
-      },
+      }
     },
     isEditing(val) {
       if (!val) {
@@ -222,7 +222,7 @@ export default {
         this.showNewContactDialog = false;
         this.relationshipChanges = [];
       }
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/CustomerListContainer.vue
+++ b/src/components/detail/CustomerListContainer.vue
@@ -100,7 +100,7 @@ export default {
     UpdateButton,
     AdditionButton,
     CustomerContactCard,
-    SelectListModal,
+    SelectListModal
   },
 
   props: {
@@ -109,7 +109,7 @@ export default {
     selectingForestCustomerId: { type: String, default: null },
     id: String,
     customer: Object,
-    contactType: String,
+    contactType: String
   },
   data() {
     return {
@@ -118,7 +118,7 @@ export default {
       contactsToDelete: [],
       relationshipChanges: [],
       contacts_: [],
-      itemsForAddingUrl: "/contacts",
+      itemsForAddingUrl: "/contacts"
     };
   },
   computed: {
@@ -131,7 +131,7 @@ export default {
     contactsAddData() {
       return [...this.contactsToAdd, ...this.relationshipChanges].map(c => ({
         contact: c.id,
-        relationship_type: c.relationship_type,
+        relationship_type: c.relationship_type
       }));
     },
     contactIdsToDelete() {
@@ -142,7 +142,7 @@ export default {
         this.contactIdsToDelete.length === 0 &&
         this.contactsAddData.length === 0
       );
-    },
+    }
   },
   methods: {
     itemsForAddingResultFilter(c) {
@@ -159,7 +159,7 @@ export default {
     handleAdd() {
       const contactItem = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       if (contactItem) {
         contactItem.added = true;
@@ -182,7 +182,7 @@ export default {
         this.$set(contact, "relationship_type", undefined);
         this.$set(this.contacts, index, contact);
         this.relationshipChanges = reject(this.relationshipChanges, {
-          id: contact.id,
+          id: contact.id
         });
         this.contactsToDelete.push(contact);
       }
@@ -198,7 +198,7 @@ export default {
           adding: this.contactsAddData,
           deleting: this.contactIdsToDelete,
           contact_type: this.contactType || "FOREST",
-          forest_id: this.selectingForestId,
+          forest_id: this.selectingForestId
         });
         this.$emit("saved");
         this.saving = false;
@@ -210,11 +210,11 @@ export default {
         this.saving = false;
         if (error.response && error.response.status === 400) {
           this.$dialog.notify.error(
-            this.$t("messages.record_updated_before_please_reload_first"),
+            this.$t("messages.record_updated_before_please_reload_first")
           );
         }
       }
-    },
+    }
   },
   watch: {
     selectingForestId() {
@@ -225,7 +225,7 @@ export default {
       deep: true,
       handler(val) {
         this.contacts_ = cloneDeep(val);
-      },
+      }
     },
     isEditing(val) {
       if (!val) {
@@ -245,7 +245,7 @@ export default {
     },
     selectingForestCustomerId(val) {
       if (this.contactType === "FOREST" && !val) this.isEditing = false;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/DocumentCard.vue
+++ b/src/components/detail/DocumentCard.vue
@@ -49,7 +49,7 @@ export default {
     loading: Boolean,
     flat: { type: Boolean, default: false },
     deleted: { type: Boolean, default: false },
-    added: { type: Boolean, default: false },
+    added: { type: Boolean, default: false }
   },
 
   methods: {
@@ -59,7 +59,7 @@ export default {
 
     onDownload() {
       this.downloadClick();
-    },
+    }
   },
 
   computed: {
@@ -70,8 +70,8 @@ export default {
           this.attachment.attributes["original_file_name"]) ||
         this.fileName
       );
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ForestAttributeTable.vue
+++ b/src/components/detail/ForestAttributeTable.vue
@@ -38,14 +38,14 @@ export default {
 
   props: {
     isLoading: Boolean,
-    attributes: Array,
+    attributes: Array
   },
 
   computed: {
     getHeaders() {
       return headers;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ForestBasicInfo.vue
+++ b/src/components/detail/ForestBasicInfo.vue
@@ -161,7 +161,7 @@
             <select-info
               :items="[
                 { text: '加入', value: '加入' },
-                { text: '未加入', value: '未加入' },
+                { text: '未加入', value: '未加入' }
               ]"
               label="FSC認証加入"
               :value="fscStatus"
@@ -217,14 +217,14 @@ export default {
     RangeDatePicker,
     SingleDatePicker,
     ValidationObserver,
-    UpdateButton,
+    UpdateButton
   },
 
   props: {
     info: Object,
     isUpdate: Boolean,
     isSave: Boolean,
-    formErrors: Object,
+    formErrors: Object
   },
 
   data() {
@@ -235,8 +235,8 @@ export default {
       colorsMap: {
         未契約: "grey--lighten",
         期限切: "orange lighten-2",
-        契約済: "primary",
-      },
+        契約済: "primary"
+      }
     };
   },
 
@@ -254,7 +254,7 @@ export default {
         if (response) {
           this.contractTypes = response.map(item => ({
             text: item.name,
-            value: item.name,
+            value: item.name
           }));
         }
       } catch {
@@ -287,7 +287,7 @@ export default {
       if (this.innerInfo.contracts.fsc_status !== "加入") {
         const errors = {
           ...this.$refs.observer.errors,
-          "contracts.fsc_start_date": [],
+          "contracts.fsc_start_date": []
         };
         this.$refs.observer.setErrors(errors);
       }
@@ -295,7 +295,7 @@ export default {
     updateFscDate(val) {
       this.innerInfo.contracts.fsc_start_date = val[0];
       this.innerInfo.contracts.fsc_end_date = val[1];
-    },
+    }
   },
 
   async mounted() {
@@ -347,18 +347,18 @@ export default {
     contractPeriod() {
       return [
         this.contract.contract_start_date || "",
-        this.contract.contract_end_date || "",
+        this.contract.contract_end_date || ""
       ];
     },
     contractStatusesSelectItems() {
       return Object.keys(this.contractStatuses).map(key => ({
         text: this.contractStatuses[key],
-        value: this.contractStatuses[key],
+        value: this.contractStatuses[key]
       }));
     },
     landAttributes() {
       return this.innerInfo && this.innerInfo["land_attributes"];
-    },
+    }
   },
 
   watch: {
@@ -374,8 +374,8 @@ export default {
       if (!val && this.$refs.observer.flags.dirty) {
         this.innerInfo = _cloneDeep(this.info);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ForestBasicInfoContainer.vue
+++ b/src/components/detail/ForestBasicInfoContainer.vue
@@ -33,11 +33,11 @@ export default {
 
   components: {
     ContentHeader,
-    ForestBasicInfo,
+    ForestBasicInfo
   },
 
   props: {
-    info: Object,
+    info: Object
   },
 
   data() {
@@ -45,7 +45,7 @@ export default {
       isUpdate: false,
       isSave: false,
       saveDisabled: false,
-      formErrors: null,
+      formErrors: null
     };
   },
 
@@ -66,13 +66,13 @@ export default {
             this.formErrors = e.response.data.errors;
           } else {
             this.$dialog.notify.error(
-              this.$t("messages.api_update_general_error"),
+              this.$t("messages.api_update_general_error")
             );
           }
           this.isSave = false;
           this.isLoading = false;
         });
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/ForestContactTabContainer.vue
+++ b/src/components/detail/ForestContactTabContainer.vue
@@ -104,7 +104,7 @@ export default {
     SectionContainerWrapper,
     ContactTab,
     SelectListModal,
-    CustomerContactCard,
+    CustomerContactCard
   },
 
   props: {
@@ -112,7 +112,7 @@ export default {
     customersContacts: Array,
     permissions: Array,
     id: String,
-    customerIdNameMap: Object,
+    customerIdNameMap: Object
   },
   data() {
     return {
@@ -121,7 +121,7 @@ export default {
       selectingCustomerId: null,
       defaultCustomersEdit: {},
       defaultCustomersContactsEdit: {},
-      itemsForAddingUrl: "/customers",
+      itemsForAddingUrl: "/customers"
     };
   },
   computed: {
@@ -144,7 +144,7 @@ export default {
         isEmpty(this.defaultCustomersEdit) &&
         isEmpty(this.defaultCustomersContactsEdit)
       );
-    },
+    }
   },
   methods: {
     itemsForAddingResultFilter(item) {
@@ -159,7 +159,7 @@ export default {
     handleAdd() {
       const c = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       c.added = true;
       this.customersToAdd.push(c);
@@ -189,7 +189,7 @@ export default {
       this.$set(c, "deleted", undefined);
       this.$store.commit("forest/setCustomers", newCustomers);
       this.customersToDelete = reject(this.customersToDelete, {
-        id: customer.id,
+        id: customer.id
       });
     },
     async handleSave() {
@@ -201,30 +201,30 @@ export default {
         ) {
           await this.$rest.put(`/forests/${this.id}/customers/update`, {
             added: this.customerIdsToAdd,
-            deleted: this.customerIdsToDelete,
+            deleted: this.customerIdsToDelete
           });
         }
         if (!isEmpty(this.defaultCustomersEdit)) {
           for (let [customer_id, val] of Object.entries(
-            this.defaultCustomersEdit,
+            this.defaultCustomersEdit
           )) {
             await this.$store.dispatch("forest/toggleDefaultCustomer", {
               id: this.id,
               customer_id,
-              val,
+              val
             });
           }
         }
         if (!isEmpty(this.defaultCustomersContactsEdit)) {
           for (let [customercontact_id, val] of Object.entries(
-            this.defaultCustomersContactsEdit,
+            this.defaultCustomersContactsEdit
           )) {
             const [customer_id, contact_id] = customercontact_id.split(",");
             await this.$store.dispatch("forest/toggleDefaultCustomerContact", {
               id: this.id,
               customer_id,
               contact_id,
-              val,
+              val
             });
           }
           this.$emit("savedCustomersContacts");
@@ -239,7 +239,7 @@ export default {
       } catch (error) {
         if (error.response && error.response.status === 400) {
           this.$dialog.notify.error(
-            this.$t("messages.record_updated_before_please_reload_first"),
+            this.$t("messages.record_updated_before_please_reload_first")
           );
         }
         this.saving = false;
@@ -263,22 +263,22 @@ export default {
         this.$set(
           this.defaultCustomersContactsEdit,
           `${customer_id},${contact_id}`,
-          val,
+          val
         );
       else {
         delete this.defaultCustomersContactsEdit[
           `${customer_id},${contact_id}`
         ];
         this.defaultCustomersContactsEdit = {
-          ...this.defaultCustomersContactsEdit,
+          ...this.defaultCustomersContactsEdit
         };
       }
       const c = find(this.customersContacts, {
         id: contact_id,
-        customer_id: customer_id,
+        customer_id: customer_id
       });
       this.$set(c, "default", val);
-    },
+    }
   },
   watch: {
     isEditing(val) {
@@ -300,23 +300,23 @@ export default {
         for (let [cid, val] of Object.entries(this.defaultCustomersEdit)) {
           this.$store.commit("forest/toggleDefaultCustomerLocal", {
             customer_id: cid,
-            val: !val,
+            val: !val
           });
         }
         this.defaultCustomersEdit = {};
         for (let [ccid, val] of Object.entries(
-          this.defaultCustomersContactsEdit,
+          this.defaultCustomersContactsEdit
         )) {
           const [customer_id, contact_id] = ccid.split(",");
           this.$store.commit("forest/toggleDefaultCustomerContactLocal", {
             customer_id: customer_id,
             contact_id: contact_id,
-            val: !val,
+            val: !val
           });
         }
         this.defaultCustomersContactsEdit = {};
       }
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/ForestInfoCard.vue
+++ b/src/components/detail/ForestInfoCard.vue
@@ -63,7 +63,7 @@ export default {
     mode: { type: String, default: "view" },
     handleDeleteClick: Function,
     clickable: { type: Boolean, default: false },
-    forestReprOwner: { type: String },
+    forestReprOwner: { type: String }
   },
   computed: {
     actionIcon() {
@@ -71,8 +71,8 @@ export default {
     },
     selected() {
       return this.selectedId === this.card_id;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/ForestInfoList.vue
+++ b/src/components/detail/ForestInfoList.vue
@@ -32,7 +32,7 @@ export default {
   name: "forest-info-list",
 
   components: {
-    ForestInfoCard,
+    ForestInfoCard
   },
 
   props: {
@@ -40,18 +40,18 @@ export default {
     isUpdate: Boolean,
     selectedId: String,
     itemClickable: { type: Boolean, default: false },
-    echoedForestId: String,
+    echoedForestId: String
   },
 
   data() {
     return {
-      selectedForestId: null,
+      selectedForestId: null
     };
   },
 
   methods: {
     getForestDisplayName,
-    getForestReprOwner,
+    getForestReprOwner
   },
 
   watch: {
@@ -61,7 +61,7 @@ export default {
 
     selectedId(val) {
       this.selectedForestId = val;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/ForestListContainer.vue
+++ b/src/components/detail/ForestListContainer.vue
@@ -107,7 +107,7 @@ export default {
     UpdateButton,
     AdditionButton,
     SelectListModal,
-    ForestInfoCard,
+    ForestInfoCard
   },
 
   props: {
@@ -116,14 +116,14 @@ export default {
     displayAdditionBtn: Boolean,
     selectingForestId: String,
     itemClickable: { type: Boolean, default: false },
-    echoedForestIdFromMap: { type: String, default: null },
+    echoedForestIdFromMap: { type: String, default: null }
   },
   data() {
     return {
       selectingForestId_: null,
       forestsToAdd: [],
       forestsToDelete: [],
-      itemsForAddingUrl: "/forests/minimal",
+      itemsForAddingUrl: "/forests/minimal"
     };
   },
   computed: {
@@ -143,7 +143,7 @@ export default {
       return (
         this.forestIdsToDelete.length === 0 && this.forestIdsToAdd.length === 0
       );
-    },
+    }
 
     // selectedForestId() {
     //   return this.echoedForestId
@@ -158,7 +158,7 @@ export default {
     handleAdd() {
       const forestItem = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       forestItem.added = true;
       this.forestsToAdd.push(forestItem);
@@ -187,7 +187,7 @@ export default {
         this.saving = true;
         await this.$rest.put(`/customers/${this.id}/forests`, {
           added: this.forestIdsToAdd,
-          deleted: this.forestIdsToDelete,
+          deleted: this.forestIdsToDelete
         });
         this.$emit("saved");
         this.saving = false;
@@ -201,14 +201,14 @@ export default {
         this.saving = false;
         if (error.response && error.response.status === 400) {
           this.$dialog.notify.error(
-            this.$t("messages.record_updated_before_please_reload_first"),
+            this.$t("messages.record_updated_before_please_reload_first")
           );
         } else if (error.response && error.response.status < 500)
           this.$dialog.notify.error(
-            error.response.data.detail || error.response.statusText,
+            error.response.data.detail || error.response.statusText
           );
       }
-    },
+    }
   },
   watch: {
     selectingForestId_(val) {
@@ -233,7 +233,7 @@ export default {
 
     echoedForestIdFromMap(val) {
       this.selectingForestId_ = val;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/detail/LogCard.vue
+++ b/src/components/detail/LogCard.vue
@@ -30,13 +30,13 @@ export default {
     date: String,
     editor: Object,
     type: String,
-    noRightAction: { type: Boolean, default: false },
+    noRightAction: { type: Boolean, default: false }
   },
 
   methods: {
     onClick() {
       // Handle click navigate
-    },
+    }
   },
 
   computed: {
@@ -55,8 +55,8 @@ export default {
       } else {
         return "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/MemoInput.vue
+++ b/src/components/detail/MemoInput.vue
@@ -73,18 +73,18 @@ export default {
   props: {
     apiUrl: { type: String, required: true },
     value: { type: Object },
-    objectType: { type: String, required: true },
+    objectType: { type: String, required: true }
   },
   components: {
     ValidationProvider,
-    UpdateButton,
+    UpdateButton
   },
   data() {
     return {
       isLoading: false,
       isUpdate: false,
       memo: _get(this.value, "attributes.memo") || "",
-      originalMemo: "",
+      originalMemo: ""
     };
   },
   methods: {
@@ -92,7 +92,7 @@ export default {
       try {
         this.isLoading = true;
         const response = await this.$rest.post(this.apiUrl, {
-          memo: this.memo,
+          memo: this.memo
         });
         if (response) {
           this.memo = response.memo;
@@ -112,7 +112,7 @@ export default {
       this.memo = this.value.attributes["memo"] || "";
       this.isLoading = false;
       this.isUpdate = false;
-    },
+    }
   },
   computed: {
     hasPermission() {
@@ -126,14 +126,14 @@ export default {
     },
     hasChanged() {
       return this.originalMemo !== this.memo;
-    },
+    }
   },
   watch: {
     "value.attributes.memo"() {
       this.memo = this.value.attributes["memo"] || "";
       this.originalMemo = this.memo;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/SelectInfo.vue
+++ b/src/components/detail/SelectInfo.vue
@@ -20,7 +20,7 @@ export default {
   name: "text-info",
 
   components: {
-    SelectInput,
+    SelectInput
   },
 
   props: {
@@ -28,8 +28,8 @@ export default {
     label: String,
     value: [String, Number, Object],
     isUpdate: Boolean,
-    clearable: { type: Boolean, default: false },
-  },
+    clearable: { type: Boolean, default: false }
+  }
 };
 </script>
 

--- a/src/components/detail/SelectListModalMixin.js
+++ b/src/components/detail/SelectListModalMixin.js
@@ -4,7 +4,7 @@ export default {
   created() {
     this.debounceLoadInitItemsForAdding = debounce(
       this.loadInitItemsForAdding,
-      500,
+      500
     );
   },
   data() {
@@ -18,7 +18,7 @@ export default {
       modalSelectingId: null,
       modalSelectingIndex: null,
       showNotFoundMsg: false,
-      showOutOfDataMsg: false,
+      showOutOfDataMsg: false
     };
   },
   methods: {
@@ -30,8 +30,8 @@ export default {
       let reqConfig = keyword
         ? {
             params: {
-              search: keyword || "",
-            },
+              search: keyword || ""
+            }
           }
         : {};
       this.itemsForAddingLoading = true;
@@ -41,7 +41,7 @@ export default {
         this.itemsForAdding = {
           next: resp.next,
           previous: resp.previous,
-          results: reject(resp.results, this.itemsForAddingResultFilter),
+          results: reject(resp.results, this.itemsForAddingResultFilter)
         };
         this.showNotFoundMsg =
           !resp.next && !resp.previous && resp.results.length === 0;
@@ -59,11 +59,11 @@ export default {
         previous: resp.previous,
         results: [
           ...this.itemsForAdding.results,
-          ...reject(resp.results, this.itemsForAddingResultFilter),
-        ],
+          ...reject(resp.results, this.itemsForAddingResultFilter)
+        ]
       };
       this.itemsForAddingLoading = false;
-    },
+    }
   },
   watch: {
     showSelect(val) {
@@ -75,6 +75,6 @@ export default {
           this.$refs.selectListModal.clearSearch();
         }
       }
-    },
-  },
+    }
+  }
 };

--- a/src/components/detail/SettingsContainer.vue
+++ b/src/components/detail/SettingsContainer.vue
@@ -11,7 +11,7 @@ export default {
     return {
       isLoading_: false,
       contractTypes: [],
-      contractTypeInput: "",
+      contractTypeInput: ""
     };
   },
   created() {
@@ -26,13 +26,13 @@ export default {
   computed: {
     contractTypeNames() {
       return this.contractTypes.map(ct => ct.name);
-    },
+    }
   },
   methods: {
     async addContractTypeBtnClick() {
       try {
         const newType = await this.$rest.post("/contract_type", {
-          name: this.contractTypeInput,
+          name: this.contractTypeInput
         });
         this.contractTypes.push(newType);
         this.contractTypeInput = "";
@@ -47,8 +47,8 @@ export default {
     },
     toggleActive(id, val) {
       this.$rest.put(`contract_type/${id}/toggle-active`, { active: val });
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/detail/TextInfo.vue
+++ b/src/components/detail/TextInfo.vue
@@ -21,7 +21,7 @@ export default {
   name: "text-info",
 
   components: {
-    TextInput,
+    TextInput
   },
 
   props: {
@@ -29,14 +29,14 @@ export default {
     value: [String, Number],
     rules: String,
     name: String,
-    isUpdate: Boolean,
+    isUpdate: Boolean
   },
 
   data() {
     return {
-      innerValue: "",
+      innerValue: ""
     };
-  },
+  }
 };
 </script>
 

--- a/src/components/detail/UpdateButton.vue
+++ b/src/components/detail/UpdateButton.vue
@@ -28,8 +28,8 @@ export default {
     cancel: Function,
     saveDisabled: Boolean,
     saving: Boolean,
-    small: Boolean,
-  },
+    small: Boolean
+  }
 };
 </script>
 

--- a/src/components/dialogs/UpdateActionsDialog.vue
+++ b/src/components/dialogs/UpdateActionsDialog.vue
@@ -71,7 +71,7 @@ export default {
   components: {
     ValidationObserver,
     ValidationProvider,
-    TextInput,
+    TextInput
   },
 
   props: {
@@ -80,14 +80,14 @@ export default {
     showDialog: Boolean,
     loadingItems: Boolean,
     updating: Boolean,
-    cancel: Function,
+    cancel: Function
   },
 
   data() {
     return {
       selectedItem: "",
       newValue: "",
-      isShowDialog: null,
+      isShowDialog: null
     };
   },
 
@@ -113,7 +113,7 @@ export default {
     onCancel() {
       this.cancel();
       this.setDefault();
-    },
+    }
   },
 
   watch: {
@@ -123,8 +123,8 @@ export default {
 
     showDialog(val) {
       this.isShowDialog = cloneDeep(val);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/forms/ActivateAccountForm.vue
+++ b/src/components/forms/ActivateAccountForm.vue
@@ -20,7 +20,7 @@
                 <v-alert dense outlined type="success">
                   {{
                     $t("messages.activate_account_success", {
-                      seconds: redirectCount,
+                      seconds: redirectCount
                     })
                   }}
                 </v-alert>
@@ -118,7 +118,7 @@ import TextInput from "../forms/TextInput";
 export default {
   components: {
     TextInput,
-    ValidationObserver,
+    ValidationObserver
   },
   data() {
     return {
@@ -126,14 +126,14 @@ export default {
         first_name: "",
         last_name: "",
         password: "",
-        password_retype: "",
+        password_retype: ""
       },
       formError: "",
       loading: false,
       showPassword: false,
       success: false,
       redirectInterval: null,
-      redirectCount: 3,
+      redirectCount: 3
     };
   },
   methods: {
@@ -146,7 +146,7 @@ export default {
           new_password: this.form.password,
           re_new_password: this.form.password_retype,
           first_name: this.form.first_name,
-          last_name: this.form.last_name,
+          last_name: this.form.last_name
         });
         this.success = true;
         this.redirectInterval = setInterval(() => {
@@ -171,7 +171,7 @@ export default {
       } finally {
         this.loading = false;
       }
-    },
+    }
   },
   created() {
     extend("password", {
@@ -179,7 +179,7 @@ export default {
       validate(value, { target }) {
         return value === target;
       },
-      message: this.$t("activate_form.password_not_match"),
+      message: this.$t("activate_form.password_not_match")
     });
   },
   watch: {
@@ -187,8 +187,8 @@ export default {
       if (val) {
         this.formError = "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/forms/BankingInfoForm.vue
+++ b/src/components/forms/BankingInfoForm.vue
@@ -8,14 +8,14 @@ setInteractionMode("eager");
 export default {
   components: {
     ValidationObserver,
-    TextInput,
+    TextInput
   },
   props: ["formData", "id", "toggleEditing"],
   data() {
     return {
       shown: false,
       submiting: false,
-      form: {},
+      form: {}
     };
   },
   mounted() {
@@ -42,8 +42,8 @@ export default {
     handleCancel() {
       this.form = { ...this.formData };
       this.toggleEditing();
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/forms/ContactForm.vue
+++ b/src/components/forms/ContactForm.vue
@@ -160,7 +160,7 @@ setInteractionMode("eager");
 export default {
   components: {
     ValidationObserver,
-    TextInput,
+    TextInput
   },
   props: {
     formData: { type: Object, default: () => {} },
@@ -168,13 +168,13 @@ export default {
     toggleEditing: { type: Function },
     showCancel: { type: Boolean },
     handleSubmit: { type: Function },
-    errors: { type: Object, default: () => {} },
+    errors: { type: Object, default: () => {} }
   },
   data() {
     return {
       shown: false,
       form: this.formData,
-      submiting: false,
+      submiting: false
     };
   },
   mounted() {
@@ -185,7 +185,7 @@ export default {
   computed: {
     fieldNamePrefix() {
       return this.handleSubmit ? "" : "basic_contact.";
-    },
+    }
   },
   watch: {
     errors: {
@@ -193,14 +193,14 @@ export default {
         if (isEmpty(val)) this.$refs.form.reset();
         else this.$refs.form.setErrors(val);
       },
-      deep: true,
+      deep: true
     },
     form(val) {
       this.$emit("update:formData", val);
     },
     formData(val) {
       if (val !== this.form) this.form = val;
-    },
+    }
   },
   methods: {
     handleCancel() {
@@ -221,22 +221,22 @@ export default {
         basic_contact: {
           name_kanji: {
             last_name: this.form.last_name_kanji,
-            first_name: this.form.first_name_kanji,
+            first_name: this.form.first_name_kanji
           },
           name_kana: {
             last_name: this.form.last_name_kana,
-            first_name: this.form.first_name_kana,
+            first_name: this.form.first_name_kana
           },
           address: {
             sector: this.form.sector,
             prefecture: this.form.prefecture,
-            municipality: this.form.municipality,
+            municipality: this.form.municipality
           },
           postal_code: this.form.postal_code,
           telephone: this.form.telephone,
           mobilephone: this.form.mobilephone,
-          email: this.form.email,
-        },
+          email: this.form.email
+        }
       };
       try {
         if (!this.id) {
@@ -244,7 +244,7 @@ export default {
           this.submiting = false;
           this.$router.push({
             name: "customer-detail",
-            params: { id: data.business_id },
+            params: { id: data.business_id }
           });
         } else {
           await this.$rest.put(`/customers/${this.id}`, customerInput);
@@ -258,7 +258,7 @@ export default {
       } finally {
         this.submiting = false;
       }
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/forms/CreateUserForm.vue
+++ b/src/components/forms/CreateUserForm.vue
@@ -83,19 +83,19 @@ import TextInput from "../forms/TextInput";
 export default {
   components: {
     TextInput,
-    ValidationObserver,
+    ValidationObserver
   },
   props: {
-    show: { type: Boolean },
+    show: { type: Boolean }
   },
   data() {
     return {
       form: {
-        email: "",
+        email: ""
       },
       formError: "",
       loading: false,
-      successfulEmail: null,
+      successfulEmail: null
     };
   },
   methods: {
@@ -132,7 +132,7 @@ export default {
         const password = this.randomPassword();
         const response = await this.$rest.post("/users", {
           ...this.form,
-          password,
+          password
         });
 
         if (response) {
@@ -148,7 +148,7 @@ export default {
       } finally {
         this.loading = false;
       }
-    },
+    }
   },
   watch: {
     show(val) {
@@ -157,12 +157,12 @@ export default {
         this.successfulEmail = null;
         this.formError = "";
         this.form = {
-          email: "",
+          email: ""
         };
         this.$refs.form.reset();
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/forms/ForgotPasswordForm.vue
+++ b/src/components/forms/ForgotPasswordForm.vue
@@ -82,16 +82,16 @@ import TextInput from "../forms/TextInput";
 export default {
   components: {
     TextInput,
-    ValidationObserver,
+    ValidationObserver
   },
   data() {
     return {
       form: {
-        email: "",
+        email: ""
       },
       formError: "",
       success: false,
-      loading: false,
+      loading: false
     };
   },
   methods: {
@@ -99,7 +99,7 @@ export default {
       try {
         this.loading = true;
         await this.$rest.post(`/users/reset_password`, {
-          email: this.form.email,
+          email: this.form.email
         });
         this.success = true;
       } catch (err) {
@@ -108,20 +108,20 @@ export default {
       } finally {
         this.loading = false;
       }
-    },
+    }
   },
   computed: {
     mailSent: function() {
       return this.success;
-    },
+    }
   },
   watch: {
     success(val) {
       if (val) {
         this.formError = "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/forms/LoginForm.vue
+++ b/src/components/forms/LoginForm.vue
@@ -84,17 +84,17 @@ import TextInput from "../forms/TextInput";
 export default {
   components: {
     TextInput,
-    ValidationObserver,
+    ValidationObserver
   },
   data() {
     return {
       form: {
         email: "",
-        password: "",
+        password: ""
       },
       formError: "",
       loading: false,
-      success: false,
+      success: false
     };
   },
   methods: {
@@ -129,11 +129,11 @@ export default {
         const response = await this.$rest.post(
           "/token/create/",
           {
-            ...this.form,
+            ...this.form
           },
           {
-            no_activity: true,
-          },
+            no_activity: true
+          }
         );
 
         if (response) {
@@ -158,15 +158,15 @@ export default {
           this.loading = false;
         }, 500);
       }
-    },
+    }
   },
   watch: {
     success(val) {
       if (val) {
         this.formError = "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/components/forms/ResetPasswordConfirmForm.vue
+++ b/src/components/forms/ResetPasswordConfirmForm.vue
@@ -20,7 +20,7 @@
                 <v-alert dense outlined type="success">
                   {{
                     $t("messages.reset_password_success", {
-                      seconds: redirectCount,
+                      seconds: redirectCount
                     })
                   }}
                 </v-alert>
@@ -99,20 +99,20 @@ import TextInput from "../forms/TextInput";
 export default {
   components: {
     TextInput,
-    ValidationObserver,
+    ValidationObserver
   },
   data() {
     return {
       form: {
         password: "",
-        password_retype: "",
+        password_retype: ""
       },
       formError: "",
       loading: false,
       showPassword: false,
       success: false,
       redirectInterval: null,
-      redirectCount: 3,
+      redirectCount: 3
     };
   },
   methods: {
@@ -123,7 +123,7 @@ export default {
           uid: this.$route.params.uid,
           token: this.$route.params.token,
           new_password: this.form.password,
-          re_new_password: this.form.password_retype,
+          re_new_password: this.form.password_retype
         });
         this.success = true;
         this.redirectInterval = setInterval(() => {
@@ -146,8 +146,8 @@ export default {
         if (val) {
           this.formError = "";
         }
-      },
-    },
+      }
+    }
   },
   created() {
     extend("password", {
@@ -155,9 +155,9 @@ export default {
       validate(value, { target }) {
         return value === target;
       },
-      message: this.$t("reset_password_form.password_not_match"),
+      message: this.$t("reset_password_form.password_not_match")
     });
-  },
+  }
 };
 </script>
 

--- a/src/components/forms/SelectInput.vue
+++ b/src/components/forms/SelectInput.vue
@@ -30,61 +30,61 @@ import { ValidationProvider } from "vee-validate";
 
 export default {
   components: {
-    ValidationProvider,
+    ValidationProvider
   },
   props: {
     vid: {
       type: String,
-      default: undefined,
+      default: undefined
     },
     items: {
-      type: Array,
+      type: Array
     },
     name: {
       type: String,
-      default: "",
+      default: ""
     },
     label: {
       type: String,
-      default: "",
+      default: ""
     },
     rules: {
       type: [Object, String],
-      default: "",
+      default: ""
     },
     placeholder: {
       type: String,
-      default: "",
+      default: ""
     },
     hideDetails: {
       type: [String, Boolean],
-      default: "auto",
+      default: "auto"
     },
     value: {
       type: null,
-      default: "",
+      default: ""
     },
-    clearable: { type: Boolean, default: false },
+    clearable: { type: Boolean, default: false }
   },
   data: () => ({
-    innerValue: "",
+    innerValue: ""
   }),
   computed: {
     hasValue() {
       return !!this.innerValue;
-    },
+    }
   },
   watch: {
     value(val) {
       if (val !== this.innerValue) {
         this.innerValue = val;
       }
-    },
+    }
   },
   created() {
     if (this.value) {
       this.innerValue = this.value;
     }
-  },
+  }
 };
 </script>

--- a/src/components/forms/TextInput.vue
+++ b/src/components/forms/TextInput.vue
@@ -30,33 +30,33 @@ import { ValidationProvider } from "vee-validate";
 export default {
   name: "text-input",
   components: {
-    ValidationProvider,
+    ValidationProvider
   },
   props: {
     vid: {
       type: String,
-      default: undefined,
+      default: undefined
     },
     name: {
       type: String,
-      default: "",
+      default: ""
     },
     label: {
       type: String,
-      default: "",
+      default: ""
     },
     rules: {
       type: [Object, String],
-      default: "",
+      default: ""
     },
     placeholder: {
       type: String,
-      default: "",
+      default: ""
     },
     disabled: { type: Boolean, default: false },
     hideDetails: {
       type: [String, Boolean],
-      default: "auto",
+      default: "auto"
     },
     type: {
       type: String,
@@ -69,27 +69,27 @@ export default {
           "tel",
           "search",
           "number",
-          "email",
+          "email"
         ].includes(value);
-      },
+      }
     },
     value: {
       type: null,
-      default: "",
+      default: ""
     },
     maxLength: Number,
     clearable: {
       type: Boolean,
-      default: false,
-    },
+      default: false
+    }
   },
   data: () => ({
-    innerValue: "",
+    innerValue: ""
   }),
   computed: {
     hasValue() {
       return !!this.innerValue;
-    },
+    }
   },
   watch: {
     innerValue(value) {
@@ -99,12 +99,12 @@ export default {
       if (val !== this.innerValue) {
         this.innerValue = val;
       }
-    },
+    }
   },
   created() {
     if (this.value) {
       this.innerValue = this.value;
     }
-  },
+  }
 };
 </script>

--- a/src/components/tags/TagDetailCard.vue
+++ b/src/components/tags/TagDetailCard.vue
@@ -155,11 +155,11 @@ export default {
     objectType: { type: String, required: true },
     objectId: { type: String },
     title: { type: String, default: "タグ情報" },
-    editable: { type: Boolean, default: true },
+    editable: { type: Boolean, default: true }
   },
   components: {
     UpdateButton,
-    TagSettingManage,
+    TagSettingManage
   },
   data() {
     return {
@@ -172,7 +172,7 @@ export default {
       tagValueSearchInput: "",
       editingTags: this.mapTagsToEditingValues(this.tags),
       originalTags: { ...this.tags },
-      tagSettingDialog: false,
+      tagSettingDialog: false
     };
   },
   async mounted() {
@@ -206,9 +206,9 @@ export default {
               .filter(item => item.value && !item.deleted)
               .map(item => ({
                 tag_name: item.key,
-                value: item.value,
-              })),
-          },
+                value: item.value
+              }))
+          }
         );
         if (results) {
           this.$emit("input", results.tags);
@@ -224,7 +224,7 @@ export default {
     },
     async getTagSettings() {
       const tagSettings = await this.$rest.get(
-        `/tags/settings/${this.appName}/${this.objectType}`,
+        `/tags/settings/${this.appName}/${this.objectType}`
       );
       if (tagSettings && tagSettings.results) {
         this.settings = tagSettings.results;
@@ -232,7 +232,7 @@ export default {
     },
     async getTagValues() {
       const tags = await this.$rest.get(
-        `/tags/${this.appName}/${this.objectType}`,
+        `/tags/${this.appName}/${this.objectType}`
       );
       if (tags && tags.results) {
         this.tagValues = tags.results;
@@ -263,7 +263,7 @@ export default {
           key: this.selectedTagKey,
           value: this.trimmedTagValueSearchInput,
           added: true,
-          deleted: false,
+          deleted: false
         });
       }
       this.tagValueSearchInput = "";
@@ -278,12 +278,12 @@ export default {
             value: tags[tagKey],
             added: false,
             edited: false,
-            deleted: false,
+            deleted: false
           });
         }
       }
       return results;
-    },
+    }
   },
   computed: {
     availableEditingTags() {
@@ -297,9 +297,7 @@ export default {
       return (
         this.editingTags.filter(
           item =>
-            item.added === true ||
-            item.edited === true ||
-            item.deleted === true,
+            item.added === true || item.edited === true || item.deleted === true
         ).length > 0
       );
     },
@@ -320,7 +318,7 @@ export default {
     },
     trimmedSelectedTagKey() {
       return this.selectedTagKey && this.selectedTagKey.trim();
-    },
+    }
   },
   watch: {
     tags: {
@@ -328,7 +326,7 @@ export default {
       handler(val) {
         this.originalTags = { ...val };
         this.editingTags = this.mapTagsToEditingValues(this.originalTags);
-      },
+      }
     },
     selectedTagKey() {
       this.selectedTagValue = "";
@@ -338,8 +336,8 @@ export default {
         await this.getTagSettings();
         await this.getTagValues();
       }
-    },
-  },
+    }
+  }
 };
 </script>
 <style lang="scss">

--- a/src/components/tags/TagSettingColorItem.vue
+++ b/src/components/tags/TagSettingColorItem.vue
@@ -68,7 +68,7 @@ export default {
     updateTagItemColor: { type: Function, required: true },
     item: { type: Object, required: true },
     id: { type: [String, Number] },
-    showDelete: { type: Boolean, default: false },
+    showDelete: { type: Boolean, default: false }
   },
   methods: {
     _getItemStyle(item) {
@@ -79,7 +79,7 @@ export default {
     },
     _onDeleteColorSetting(item) {
       return this.$emit("setting-deleted", { item, id: this.id });
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/components/tags/TagSettingManage.vue
+++ b/src/components/tags/TagSettingManage.vue
@@ -156,7 +156,7 @@ export default {
   props: {
     appName: { type: String, required: true },
     objectType: { type: String, required: true },
-    showDialog: { type: Boolean, default: false },
+    showDialog: { type: Boolean, default: false }
   },
   components: { TagSettingColorItem },
   data() {
@@ -169,29 +169,29 @@ export default {
       tagValues: [],
       colorMaps: [],
       selectedTag: {
-        ...this.buildTagSetting(),
+        ...this.buildTagSetting()
       },
       originalSelectedTag: {
-        ...this.buildTagSetting(),
+        ...this.buildTagSetting()
       },
       selectedTagMigrateInfo: null,
       addingColorItem: {
         value: "",
-        color: "#FF0000",
-      },
+        color: "#FF0000"
+      }
     };
   },
   created() {
     this.debouncedGetMigrateInfo = debounce(
       async () => await this.getTagMigrateInfo(),
-      300,
+      300
     );
   },
   methods: {
     updateTagItemColor(colorVal, item) {
       const colors = this.selectedTag.attributes.colors || [];
       const itemIndex = colors.findIndex(
-        setting => setting.value === item.value,
+        setting => setting.value === item.value
       );
       if (itemIndex > -1) {
         colors[itemIndex].color = colorVal.hex;
@@ -208,12 +208,12 @@ export default {
         width: "20px",
         marginTop: "3px",
         borderRadius: menu ? "50%" : "4px",
-        transition: "border-radius 200ms ease-in-out",
+        transition: "border-radius 200ms ease-in-out"
       };
     },
     async getTagValues() {
       const tags = await this.$rest.get(
-        `/tags/${this.appName}/${this.objectType}`,
+        `/tags/${this.appName}/${this.objectType}`
       );
       if (tags && tags.results) {
         this.tagValues = tags.results;
@@ -221,12 +221,12 @@ export default {
     },
     async getTagSettings() {
       const response = await this.$rest.get(
-        `/tags/settings/${this.appName}/${this.objectType}`,
+        `/tags/settings/${this.appName}/${this.objectType}`
       );
       if (response && response.results) {
         this.tagSettings = response.results.map(item => ({
           ...item,
-          original_name: item.name,
+          original_name: item.name
         }));
       }
     },
@@ -236,10 +236,10 @@ export default {
     buildTagSetting() {
       return {
         attributes: {
-          colors: [],
+          colors: []
         },
         code: "",
-        name: "",
+        name: ""
       };
     },
     switchToAddNew() {
@@ -266,8 +266,8 @@ export default {
         const confirm = await this.$dialog.confirm({
           title: this.$t("tags.migrate_title"),
           text: this.$t("tags.confirm_migrate", {
-            total: this.selectedTagMigrateInfo,
-          }),
+            total: this.selectedTagMigrateInfo
+          })
         });
         if (!confirm) {
           return;
@@ -283,17 +283,17 @@ export default {
             id: this.selectedTag.id,
             name: this.selectedTag.name,
             code: this.selectedTag.code,
-            color_maps: this.colorMaps,
+            color_maps: this.colorMaps
           },
           {
-            no_activity: true,
-          },
+            no_activity: true
+          }
         );
         if (response) {
           await this.getTagSettings();
           this.selectedTag = {
             ...response.results,
-            original_name: response.results.name,
+            original_name: response.results.name
           };
           this.onSelectedTagIdChanged();
         }
@@ -320,11 +320,11 @@ export default {
           {
             name: this.selectedTag.name,
             code: this.selectedTag.code,
-            color_maps: this.colorMaps,
+            color_maps: this.colorMaps
           },
           {
-            no_activity: true,
-          },
+            no_activity: true
+          }
         );
         if (response && response.results) {
           await this.getTagSettings();
@@ -341,11 +341,11 @@ export default {
         const response = await this.$rest.post(
           `/tags/${this.appName}/${this.objectType}/delete`,
           {
-            id: this.selectedTag.id,
+            id: this.selectedTag.id
           },
           {
-            no_activity: true,
-          },
+            no_activity: true
+          }
         );
         if (response) {
           await this.getTagSettings();
@@ -363,11 +363,11 @@ export default {
           {
             from_key: this.selectedTag.original_name,
             to_key: this.selectedTag.name,
-            do_update: false,
+            do_update: false
           },
           {
-            no_activity: true,
-          },
+            no_activity: true
+          }
         );
         if (response) {
           this.selectedTagMigrateInfo = response.total;
@@ -394,14 +394,14 @@ export default {
       }
       if (
         this.colorMaps.findIndex(
-          item => item.value === this.addingColorItem.value,
+          item => item.value === this.addingColorItem.value
         ) > -1
       ) {
         return;
       }
       this.colorMaps.push({
         ...this.addingColorItem,
-        menu: false,
+        menu: false
       });
       this.initAddingColorItem();
     },
@@ -416,7 +416,7 @@ export default {
         this.selectedTag = { ...tag };
       }
       this.originalSelectedTag = cloneDeep(this.selectedTag);
-    },
+    }
   },
   computed: {
     isEditing() {
@@ -425,10 +425,10 @@ export default {
     hasChanged() {
       const colors = this.colorMaps.map(item => ({
         color: item.color,
-        value: item.value,
+        value: item.value
       }));
       const originalColorsAttrs = JSON.parse(
-        JSON.stringify(_get(this.originalSelectedTag, "attributes.colors", [])),
+        JSON.stringify(_get(this.originalSelectedTag, "attributes.colors", []))
       );
       return (
         !isEqual(this.selectedTag, this.originalSelectedTag) ||
@@ -437,7 +437,7 @@ export default {
     },
     canSave() {
       return this.selectedTag.name && this.selectedTag.name.length > 0;
-    },
+    }
   },
   watch: {
     async showDialog(val) {
@@ -460,13 +460,13 @@ export default {
         ) {
           this.colorMaps = this.selectedTag.attributes.colors.map(item => ({
             ...item,
-            menu: false,
+            menu: false
           }));
         } else {
           this.initAddingColorItem();
           this.colorMaps = [];
         }
-      },
+      }
     },
     "selectedTag.name"(val) {
       if (
@@ -491,8 +491,8 @@ export default {
       } else {
         this.selectedTagId = null;
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/helpers/datetime.js
+++ b/src/helpers/datetime.js
@@ -9,7 +9,7 @@ export function fromNow(dateTimeString) {
   }
   return formatDistanceToNow(parseISO(dateTimeString), {
     addSuffix: true,
-    locale: ja,
+    locale: ja
   });
 }
 

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -33,10 +33,10 @@ export default {
   data() {
     return {
       cssProps: {
-        backgroundImage: `url(${background})`,
-      },
+        backgroundImage: `url(${background})`
+      }
     };
-  },
+  }
 };
 </script>
 

--- a/src/main.js
+++ b/src/main.js
@@ -24,13 +24,13 @@ setupRouter(router);
 
 Vue.use(HttpClientPlugin);
 Vue.use(VeeValidate, {
-  i18n,
+  i18n
 });
 Vue.use(AclSetup);
 Vue.use(VuetifyDialog, {
   context: {
-    vuetify,
-  },
+    vuetify
+  }
 });
 Vue.use(ActionLog);
 Vue.use(VueMask);
@@ -41,7 +41,7 @@ const vm = new Vue({
   i18n,
   router,
   apolloProvider: createProvider(),
-  render: h => h(App),
+  render: h => h(App)
 });
 
 vm.$mount("#app");

--- a/src/plugins/acl.js
+++ b/src/plugins/acl.js
@@ -11,9 +11,9 @@ const AclSetup = {
         ) {
           vnode.elm.parentElement.removeChild(vnode.elm);
         }
-      },
+      }
     });
-  },
+  }
 };
 
 export default AclSetup;

--- a/src/plugins/action-log.js
+++ b/src/plugins/action-log.js
@@ -5,9 +5,9 @@ const ActionLogSetup = {
     Vue.prototype.$actionLog = {
       reload() {
         busEvent.$emit("action-log:reload");
-      },
+      }
     };
-  },
+  }
 };
 
 export default ActionLogSetup;

--- a/src/plugins/http.js
+++ b/src/plugins/http.js
@@ -9,7 +9,7 @@ const setupRestClient = options => {
 
   axios.defaults = {
     ...axios.defaults,
-    ...options,
+    ...options
   };
 
   axios.interceptors.request.use(
@@ -27,7 +27,7 @@ const setupRestClient = options => {
       return new Promise((resolve, reject) => {
         reject(error);
       });
-    },
+    }
   );
 
   axios.interceptors.response.use(
@@ -56,8 +56,8 @@ const setupRestClient = options => {
             axios.$v.$t("messages.permission_denied"),
             {
               position: "top-right",
-              timeout: 5000,
-            },
+              timeout: 5000
+            }
           );
           reject(error);
         });
@@ -68,7 +68,7 @@ const setupRestClient = options => {
       } else if (error.response && error.response.status === 503) {
         axios.$v.$dialog.notify.error("Maintain", {
           position: "top-right",
-          timeout: 5000,
+          timeout: 5000
         });
         return new Promise((resolve, reject) => {
           reject(error);
@@ -76,13 +76,13 @@ const setupRestClient = options => {
       } else {
         axios.$v.$dialog.notify.error(`${error}`, {
           position: "top-right",
-          timeout: 5000,
+          timeout: 5000
         });
         return new Promise((resolve, reject) => {
           reject(error);
         });
       }
-    },
+    }
   );
 
   return axios;
@@ -91,7 +91,7 @@ const setupRestClient = options => {
 const HttpClientPlugin = {
   install: (Vue, options) => {
     Vue.prototype.$rest = setupRestClient(options);
-  },
+  }
 };
 
 export { HttpClientPlugin };

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -14,20 +14,20 @@ const messages = {
       ...jpValidationMessages.messages,
       min_value: "{_field_}は{min}以上の数値でなければなりません。",
       daterange: "不正な期間です。",
-      telephone: "電話番号は1桁から10桁までの数字を入力してください。",
-    },
+      telephone: "電話番号は1桁から10桁までの数字を入力してください。"
+    }
   },
   en: {
     ...enMessages,
-    validations: enValidationMessages.messages,
-  },
+    validations: enValidationMessages.messages
+  }
 };
 
 const i18n = new VueI18n({
   fallbackLocale: "jp",
   locale: "jp",
   messages,
-  silentTranslationWarn: process.env.NODE_ENV === "production",
+  silentTranslationWarn: process.env.NODE_ENV === "production"
 });
 
 export default i18n;

--- a/src/plugins/setup-router.js
+++ b/src/plugins/setup-router.js
@@ -25,7 +25,7 @@ const setupRouter = router => {
     if (localStorage.getItem("accessToken") == null) {
       return next({
         path: "/auth/login",
-        params: { nextUrl: to.fullPath },
+        params: { nextUrl: to.fullPath }
       });
     }
 
@@ -39,11 +39,11 @@ const setupRouter = router => {
 
     if (
       to.matched.some(
-        record => record.meta.scopes && record.meta.scopes.length > 0,
+        record => record.meta.scopes && record.meta.scopes.length > 0
       )
     ) {
       const scopes = uniq(
-        flattenDeep(to.matched.map(record => record.meta.scopes)),
+        flattenDeep(to.matched.map(record => record.meta.scopes))
       );
       const matchedScopes = intersection(scopes, getScopes());
 

--- a/src/plugins/vue-apollo.js
+++ b/src/plugins/vue-apollo.js
@@ -1,6 +1,6 @@
 import {
   createApolloClient,
-  restartWebsockets,
+  restartWebsockets
 } from "vue-cli-plugin-apollo/graphql-client";
 
 import Vue from "vue";
@@ -40,7 +40,7 @@ const defaultOptions = {
   // You need to pass a `wsEndpoint` for this to work
   websocketsOnly: false,
   // Is being rendered on the server?
-  ssr: false,
+  ssr: false
   // Override default apollo link
   // note: don't override httpLink here, specify httpLink options in the
   // httpLinkOptions property of defaultOptions.
@@ -64,7 +64,7 @@ export function createProvider(options = {}) {
   // Create apollo client
   const { apolloClient, wsClient } = createApolloClient({
     ...defaultOptions,
-    ...options,
+    ...options
   });
 
   apolloClient.wsClient = wsClient;
@@ -74,17 +74,17 @@ export function createProvider(options = {}) {
     defaultClient: apolloClient,
     defaultOptions: {
       $query: {
-        fetchPolicy: "cache-and-network",
-      },
+        fetchPolicy: "cache-and-network"
+      }
     },
     errorHandler(error) {
       // eslint-disable-next-line no-console
       console.log(
         "%cError",
         "background: red; color: white; padding: 2px 4px; border-radius: 3px; font-weight: bold;",
-        error.message,
+        error.message
       );
-    },
+    }
   });
 
   return apolloProvider;

--- a/src/plugins/vue-veevalidate.js
+++ b/src/plugins/vue-veevalidate.js
@@ -21,14 +21,14 @@ const setupVeeValidate = ({ i18n }) => {
     defaultMessage: (field, values) => {
       values._field_ = i18n.t(`${field}`);
       return i18n.t(`validations.${values._rule_}`, values);
-    },
+    }
   });
 };
 
 const VeeValidate = {
   install: (Vue, options) => {
     setupVeeValidate({ ...options });
-  },
+  }
 };
 
 export default VeeValidate;

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -9,8 +9,8 @@ export default new Vuetify({
   theme: {
     themes: {
       light: {
-        primary: "#12c7a6",
-      },
-    },
-  },
+        primary: "#12c7a6"
+      }
+    }
+  }
 });

--- a/src/router.js
+++ b/src/router.js
@@ -25,12 +25,12 @@ const UserProfileRoutes = [
         meta: {
           title: "page_header.user_profile",
           isPublic: false,
-          detail: true,
+          detail: true
         },
-        component: () => import("./screens/AccountProfile.vue"),
-      },
-    ],
-  },
+        component: () => import("./screens/AccountProfile.vue")
+      }
+    ]
+  }
 ];
 
 const AdminRoutes = [
@@ -44,9 +44,9 @@ const AdminRoutes = [
         meta: {
           title: "page_header.user_mgmt",
           isPublic: false,
-          scopes: ["group_admin"],
+          scopes: ["group_admin"]
         },
-        component: () => import("./screens/UserList.vue"),
+        component: () => import("./screens/UserList.vue")
       },
       {
         path: ":id",
@@ -54,12 +54,12 @@ const AdminRoutes = [
         meta: {
           title: "page_header.user_detail",
           isPublic: false,
-          scopes: ["group_admin"],
+          scopes: ["group_admin"]
         },
-        component: () => import("./screens/UserDetail.vue"),
-      },
-    ],
-  },
+        component: () => import("./screens/UserDetail.vue")
+      }
+    ]
+  }
 ];
 
 const AuthRoutes = [
@@ -70,65 +70,65 @@ const AuthRoutes = [
       {
         path: "",
         redirect: {
-          name: "auth-login",
-        },
+          name: "auth-login"
+        }
       },
       {
         path: "login",
         name: "auth-login",
         meta: {
           title: "page_header.login",
-          isPublic: true,
+          isPublic: true
         },
-        component: () => import("./screens/AuthLogin.vue"),
+        component: () => import("./screens/AuthLogin.vue")
       },
       {
         path: "logout",
         name: "auth-logout",
         meta: {
           title: "page_header.logout",
-          isPublic: false,
+          isPublic: false
         },
-        component: () => import("./screens/AuthLogout.vue"),
+        component: () => import("./screens/AuthLogout.vue")
       },
       {
         path: "forgot-password",
         name: "auth-forgot-password",
         meta: {
           title: "page_header.forgot_password",
-          isPublic: true,
+          isPublic: true
         },
-        component: () => import("./screens/AuthResetPassword.vue"),
+        component: () => import("./screens/AuthResetPassword.vue")
       },
       {
         path: "reset-password/:uid/:token",
         name: "auth-reset-password",
         meta: {
           title: "page_header.forgot_password",
-          isPublic: true,
+          isPublic: true
         },
-        component: () => import("./screens/AuthResetPasswordConfirm.vue"),
+        component: () => import("./screens/AuthResetPasswordConfirm.vue")
       },
       {
         path: "activate/:uid/:token",
         name: "auth-activate",
         meta: {
           title: "page_header.activate_account",
-          isPublic: true,
+          isPublic: true
         },
-        component: () => import("./screens/AuthActivation.vue"),
+        component: () => import("./screens/AuthActivation.vue")
       },
       {
         path: "no-permission",
         name: "error-403",
         meta: {
           title: "page_header.no_permission",
-          isPublic: true,
+          isPublic: true
         },
-        component: () => import("./screens/AuthInsufficientPermission.vue"),
-      },
-    ],
-  },
+        component: () => import("./screens/AuthInsufficientPermission.vue")
+      }
+    ]
+  }
 ];
 
 const router = new VueRouter({
@@ -141,9 +141,9 @@ const router = new VueRouter({
         {
           path: "",
           meta: {
-            isPublic: false,
+            isPublic: false
           },
-          redirect: { name: "forests" },
+          redirect: { name: "forests" }
         },
         {
           path: "/forests",
@@ -152,8 +152,8 @@ const router = new VueRouter({
           meta: {
             title: "page_header.forest_mgmt",
             isPublic: false,
-            scopes: ["manage_forest", "view_forest"],
-          },
+            scopes: ["manage_forest", "view_forest"]
+          }
         },
         {
           path: "/forests/:id",
@@ -163,8 +163,8 @@ const router = new VueRouter({
           meta: {
             title: "page_header.forest_detail",
             isPublic: false,
-            scopes: ["manage_forest", "view_forest"],
-          },
+            scopes: ["manage_forest", "view_forest"]
+          }
         },
         {
           path: "/customers",
@@ -173,8 +173,8 @@ const router = new VueRouter({
           meta: {
             title: "page_header.customer_mgmt",
             isPublic: false,
-            scopes: ["manage_customer", "view_customer"],
-          },
+            scopes: ["manage_customer", "view_customer"]
+          }
         },
         {
           path: "/customers/new",
@@ -184,8 +184,8 @@ const router = new VueRouter({
             detail: true,
             title: "page_header.customer_new",
             isPublic: false,
-            scopes: ["manage_customer", "add_customer"],
-          },
+            scopes: ["manage_customer", "add_customer"]
+          }
         },
         {
           path: "/customers/:id",
@@ -196,8 +196,8 @@ const router = new VueRouter({
             detail: true,
             title: "page_header.customer_detail",
             isPublic: false,
-            scopes: ["manage_customer", "view_customer", "admin"],
-          },
+            scopes: ["manage_customer", "view_customer", "admin"]
+          }
         },
         {
           path: "/archives",
@@ -206,8 +206,8 @@ const router = new VueRouter({
           meta: {
             title: "page_header.archive_mgmt",
             isPublic: false,
-            scopes: ["manage_archive", "view_archive"],
-          },
+            scopes: ["manage_archive", "view_archive"]
+          }
         },
         {
           path: "/archives/new",
@@ -217,8 +217,8 @@ const router = new VueRouter({
             detail: true,
             title: "page_header.archive_new",
             isPublic: false,
-            scopes: ["manage_archive"],
-          },
+            scopes: ["manage_archive"]
+          }
         },
         {
           path: "/archives/:id",
@@ -228,8 +228,8 @@ const router = new VueRouter({
             detail: true,
             title: "page_header.archive_detail",
             isPublic: false,
-            scopes: ["manage_archive", "view_archive"],
-          },
+            scopes: ["manage_archive", "view_archive"]
+          }
         },
         {
           path: "/postal-histories",
@@ -238,8 +238,8 @@ const router = new VueRouter({
           meta: {
             title: "page_header.postalhistory_mgmt",
             isPublic: false,
-            scopes: ["manage_postalhistory", "view_postalhistory"],
-          },
+            scopes: ["manage_postalhistory", "view_postalhistory"]
+          }
         },
         {
           path: "/postal-histories/new",
@@ -249,8 +249,8 @@ const router = new VueRouter({
             detail: true,
             title: "page_header.postalhistory_new",
             isPublic: false,
-            scopes: ["manage_postalhistory"],
-          },
+            scopes: ["manage_postalhistory"]
+          }
         },
         {
           path: "/postal-histories/:id",
@@ -260,10 +260,10 @@ const router = new VueRouter({
             detail: true,
             title: "page_header.postalhistory_detail",
             isPublic: false,
-            scopes: ["manage_postalhistory", "view_postalhistory"],
-          },
-        },
-      ],
+            scopes: ["manage_postalhistory", "view_postalhistory"]
+          }
+        }
+      ]
     },
     ...AdminRoutes,
     ...AuthRoutes,
@@ -277,11 +277,11 @@ const router = new VueRouter({
           name: "not-found",
           meta: {
             title: "page_header.not_found",
-            isPublic: true,
+            isPublic: true
           },
-          component: () => import("./screens/PageNotFound.vue"),
-        },
-      ],
+          component: () => import("./screens/PageNotFound.vue")
+        }
+      ]
     },
     {
       path: "/slack/oauth",
@@ -292,17 +292,17 @@ const router = new VueRouter({
           name: "slack-oauth",
           meta: {
             title: "Slack Oauth",
-            isPublic: true,
+            isPublic: true
           },
-          component: () => import("./screens/Slack/Oauth.vue"),
-        },
-      ],
+          component: () => import("./screens/Slack/Oauth.vue")
+        }
+      ]
     },
     {
       path: "*",
-      redirect: { name: "not-found" },
-    },
-  ],
+      redirect: { name: "not-found" }
+    }
+  ]
 });
 
 // Override for processing NavigationDuplicated exception

--- a/src/screens/AccountProfile.vue
+++ b/src/screens/AccountProfile.vue
@@ -154,7 +154,7 @@ export default {
     ContentHeader,
     ValidationObserver,
     UpdateButton,
-    SettingsContainer,
+    SettingsContainer
   },
 
   data() {
@@ -170,18 +170,18 @@ export default {
         group: "",
         username: "",
         email: "",
-        is_active: false,
+        is_active: false
       },
       isLoading: false,
       isUpdate: {
-        basicInfo: false,
+        basicInfo: false
       },
       errors: [],
       redirectUri:
         process.env.VUE_APP_SLACK_REDIRECT_URI ||
         (window._env && window._env.VUE_APP_SLACK_REDIRECT_URI) ||
         "http://localhost:8080/slack/oauth",
-      slackInstalls: [],
+      slackInstalls: []
     };
   },
 
@@ -204,7 +204,7 @@ export default {
     },
     async getUserPermission(callback) {
       const response = await this.$rest.get(
-        `/users/${this.userInfo && this.userInfo.id}/permissions`,
+        `/users/${this.userInfo && this.userInfo.id}/permissions`
       );
       if (response) {
         this.userPermissions = response;
@@ -241,7 +241,7 @@ export default {
       Object.keys(errors).forEach(errorKey => {
         formatedErrors.push({
           loc: errorKey,
-          message: errors[errorKey].join(", "),
+          message: errors[errorKey].join(", ")
         });
       });
 
@@ -256,7 +256,7 @@ export default {
       try {
         this.isLoading = true;
         const response = await this.$rest.put(`/users/me`, {
-          ...this.form,
+          ...this.form
         });
         if (response) {
           await this.getUserPermission();
@@ -291,8 +291,8 @@ export default {
         subTitle:
           fromNowText &&
           `${this.$t(
-            "user_management.tables.headers.last_login",
-          )} ${fromNowText}`,
+            "user_management.tables.headers.last_login"
+          )} ${fromNowText}`
       };
       this.$store.dispatch("setHeaderInfo", info);
       this.$store.dispatch("setBackBtnContent", "");
@@ -304,8 +304,7 @@ export default {
 
     copyToForm(basicInfo) {
       Object.keys(this.form).forEach(
-        key =>
-          (this.form[key] = basicInfo.find(item => item.key === key).value),
+        key => (this.form[key] = basicInfo.find(item => item.key === key).value)
       );
     },
 
@@ -314,7 +313,7 @@ export default {
         return (
           this.userPermissions.groups.map(group => ({
             text: group.name,
-            value: group.id,
+            value: group.id
           }))[0].text || {}
         );
       }
@@ -331,14 +330,14 @@ export default {
             label: this.$t("user_management.tables.headers.last_name"),
             value: userInfo.last_name,
             rules: "required",
-            name: "user_management.tables.headers.last_name",
+            name: "user_management.tables.headers.last_name"
           },
           {
             key: "first_name",
             label: this.$t("user_management.tables.headers.first_name"),
             value: userInfo.first_name,
             rules: "required",
-            name: "user_management.tables.headers.first_name",
+            name: "user_management.tables.headers.first_name"
           },
           {
             key: "username",
@@ -346,7 +345,7 @@ export default {
             value: userInfo.username,
             rules: "required",
             disabled: true,
-            name: "user_management.tables.headers.username",
+            name: "user_management.tables.headers.username"
           },
           {
             key: "email",
@@ -354,13 +353,13 @@ export default {
             value: userInfo.email,
             rules: "required|email",
             disabled: true,
-            name: "user_management.tables.headers.email",
+            name: "user_management.tables.headers.email"
           },
           {
             key: "group",
             label: this.$t("user_management.tables.headers.roles"),
             value: this.mapUserPermissions(),
-            disabled: true,
+            disabled: true
           },
           {
             key: "is_active",
@@ -368,14 +367,14 @@ export default {
             value: userInfo.is_active
               ? this.$t("enums.user_status.active")
               : this.$t("enums.user_status.inactive"),
-            disabled: true,
-          },
+            disabled: true
+          }
         ];
         this.copyToForm(basicInfo);
       }
 
       return basicInfo;
-    },
+    }
   },
 
   computed: {
@@ -385,8 +384,8 @@ export default {
 
     getActionLogs() {
       return actionLogs;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/Archive.vue
+++ b/src/screens/Archive.vue
@@ -81,7 +81,7 @@ export default {
     PageHeader,
     OutlineRoundBtn,
     TableAction,
-    UpdateActionsDialog,
+    UpdateActionsDialog
   },
 
   data() {
@@ -89,8 +89,8 @@ export default {
       actions: [
         {
           text: this.$t("action.change_tag_value"),
-          value: 0,
-        },
+          value: 0
+        }
       ],
       pageIcon: this.$t("icon.archive_icon"),
       pageHeader: this.$t("page_header.archive_detail"),
@@ -104,7 +104,7 @@ export default {
       filterQueryString: "",
       options: {},
       headers: [],
-      newTagValue: null,
+      newTagValue: null
     };
   },
 
@@ -120,7 +120,7 @@ export default {
   computed: {
     searchCriteria() {
       return this.headers.filter(h => h.text);
-    },
+    }
   },
 
   methods: {
@@ -133,7 +133,7 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
@@ -149,7 +149,7 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
@@ -182,7 +182,7 @@ export default {
         }
         return {
           criteria,
-          keyword,
+          keyword
         };
       });
       this.filterQueryString = this.arrayToQueryString(filter);
@@ -215,7 +215,7 @@ export default {
         their_participants: this.renderParticipants(data),
         our_participants: this.renderUsers(data),
         associated_forest: this.renderForests(data),
-        tags: data.tags,
+        tags: data.tags
       }));
     },
 
@@ -240,7 +240,7 @@ export default {
       const params = {
         ids: this.selectedRowIds,
         key: this.selectedTagForUpdate,
-        value: this.newTagValue,
+        value: this.newTagValue
       };
       try {
         this.updatingTags = true;
@@ -267,8 +267,8 @@ export default {
         default:
           return;
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/ArchiveDetail.vue
+++ b/src/screens/ArchiveDetail.vue
@@ -109,7 +109,7 @@ export default {
     ArchiveOtherRelatedUsersContainer,
     ActionLog,
     TagDetailCard,
-    ArchiveRelatedUserContainer,
+    ArchiveRelatedUserContainer
   },
 
   data() {
@@ -121,10 +121,10 @@ export default {
       headerInfo: {
         title: this.$t("page_header.archive_new"),
         subTitle: "",
-        backUrl: "/archives",
+        backUrl: "/archives"
       },
       participants: [],
-      participantsLoading: false,
+      participantsLoading: false
     };
   },
   created() {
@@ -146,7 +146,7 @@ export default {
         this.$rest.post(
           `/cache/archives/${this.id}`,
           {},
-          { no_activity: true },
+          { no_activity: true }
         );
       } catch {
         //ignore
@@ -156,7 +156,7 @@ export default {
       this.participantsLoading = true;
       try {
         this.participants = await this.$rest.get(
-          `/archives/${this.id}/customers`,
+          `/archives/${this.id}/customers`
         );
       } catch (error) {}
       this.participantsLoading = false;
@@ -170,7 +170,7 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
@@ -185,9 +185,9 @@ export default {
           " " +
           this.renderParticipants(this.archive),
         backUrl: "/archives",
-        tags: this.archive.tags,
+        tags: this.archive.tags
       });
-    },
+    }
   },
   computed: {
     id() {
@@ -208,7 +208,7 @@ export default {
       )
         return false;
       return true;
-    },
+    }
   },
   watch: {
     archive: {
@@ -216,9 +216,9 @@ export default {
       handler() {
         this.archiveTags = this.archive.tags;
         this.setHeaderInfo();
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>
 

--- a/src/screens/AuthActivation.vue
+++ b/src/screens/AuthActivation.vue
@@ -9,7 +9,7 @@
 import ActivateAccountForm from "../components/forms/ActivateAccountForm";
 export default {
   components: {
-    ActivateAccountForm,
-  },
+    ActivateAccountForm
+  }
 };
 </script>

--- a/src/screens/AuthLogin.vue
+++ b/src/screens/AuthLogin.vue
@@ -16,6 +16,6 @@ export default {
     if (accessToken && accessToken !== "undefined") {
       this.$router.replace("/");
     }
-  },
+  }
 };
 </script>

--- a/src/screens/AuthLogout.vue
+++ b/src/screens/AuthLogout.vue
@@ -28,6 +28,6 @@ export default {
       localStorage.clear();
       this.$router.replace({ name: "auth-login" });
     }, 1000);
-  },
+  }
 };
 </script>

--- a/src/screens/AuthResetPassword.vue
+++ b/src/screens/AuthResetPassword.vue
@@ -10,7 +10,7 @@
 import ForgotPasswordForm from "../components/forms/ForgotPasswordForm";
 export default {
   components: {
-    ForgotPasswordForm,
-  },
+    ForgotPasswordForm
+  }
 };
 </script>

--- a/src/screens/AuthResetPasswordConfirm.vue
+++ b/src/screens/AuthResetPasswordConfirm.vue
@@ -9,7 +9,7 @@
 import ResetPasswordConfirmForm from "../components/forms/ResetPasswordConfirmForm";
 export default {
   components: {
-    ResetPasswordConfirmForm,
-  },
+    ResetPasswordConfirmForm
+  }
 };
 </script>

--- a/src/screens/Customer.vue
+++ b/src/screens/Customer.vue
@@ -9,7 +9,7 @@
                 'admin',
                 'group_admin',
                 'group_normal_user',
-                'manage_customer',
+                'manage_customer'
               ]"
               icon="mdi-upload"
               :content="
@@ -26,7 +26,7 @@
                 'admin',
                 'group_admin',
                 'group_normal_user',
-                'manage_customer',
+                'manage_customer'
               ]"
               ref="csvUploadInput"
               type="file"
@@ -41,7 +41,7 @@
                 'admin',
                 'group_admin',
                 'group_normal_user',
-                'manage_customer',
+                'manage_customer'
               ]"
             >
               <template v-slot:activator="{ on }">
@@ -149,7 +149,7 @@ export default {
     PageHeader,
     OutlineRoundBtn,
     UpdateActionsDialog,
-    TableAction,
+    TableAction
   },
   mixins: [ScreenMixin],
   data() {
@@ -157,8 +157,8 @@ export default {
       actions: [
         {
           text: this.$t("action.change_tag_value"),
-          value: 0,
-        },
+          value: 0
+        }
       ],
       customerList: {},
       pageIcon: "mdi-account-outline",
@@ -170,7 +170,7 @@ export default {
       downloadCsvLoading: false,
       newTagValue: null,
       selectedFileName: "",
-      uploadCsvLoading: false,
+      uploadCsvLoading: false
     };
   },
   mounted() {
@@ -189,7 +189,7 @@ export default {
       return this.headers
         .map(h => ({ text: h.text, value: h.filter_name }))
         .filter(f => f.value !== undefined);
-    },
+    }
   },
   beforeRouteLeave(to, from, next) {
     if (this.uploadCsvLoading && !confirm(this.$t("messages.confirm_leave")))
@@ -214,7 +214,7 @@ export default {
         formData.append("file", this.$refs.csvUploadInput.files[0]);
         try {
           await this.$rest.post("/customers/upload_csv", formData, {
-            headers: { "Content-Type": "multipart/form-data" },
+            headers: { "Content-Type": "multipart/form-data" }
           });
           this.$apollo.queries.customerList.refetch();
           this.$dialog.notify.success(this.$t("messages.upload_successfully"));
@@ -226,7 +226,7 @@ export default {
           ) {
             this.$dialog.show(ErrorCard, {
               line: error.response.data.line,
-              errors: error.response.data.errors,
+              errors: error.response.data.errors
             });
           }
         } finally {
@@ -251,8 +251,8 @@ export default {
         ...config,
         headers: {
           Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
-          ...(config.headers || {}),
-        },
+          ...(config.headers || {})
+        }
       }).then(res => {
         window.writer = fileStream.getWriter();
 
@@ -261,7 +261,7 @@ export default {
           reader
             .read()
             .then(res =>
-              res.done ? writer.close() : writer.write(res.value).then(pump),
+              res.done ? writer.close() : writer.write(res.value).then(pump)
             );
 
         pump();
@@ -276,20 +276,20 @@ export default {
         {
           method: "POST",
           body: JSON.stringify({ ids }),
-          headers: { "Content-Type": "application/json" },
-        },
+          headers: { "Content-Type": "application/json" }
+        }
       );
     },
     handleDownloadAll() {
       this.downloadCsv(
         "customers.csv",
-        `${this.$rest.defaults.baseURL}/customers/download_csv`,
+        `${this.$rest.defaults.baseURL}/customers/download_csv`
       );
     },
     rowData(val) {
       this.$router.push({
         name: "customer-detail",
-        params: { id: val.business_id },
+        params: { id: val.business_id }
       });
     },
     onSearch() {
@@ -301,7 +301,7 @@ export default {
       const params = {
         ids: this.selectedRowIds,
         key: this.selectedTagForUpdate,
-        value: this.newTagValue,
+        value: this.newTagValue
       };
       try {
         this.updatingTags = true;
@@ -326,7 +326,7 @@ export default {
         default:
           return;
       }
-    },
+    }
   },
   watch: {
     options: {
@@ -338,11 +338,11 @@ export default {
           page,
           itemsPerPage,
           preItemsPerPage: old.itemsPerPage || null,
-          filters: this.requestFilters,
+          filters: this.requestFilters
         };
       },
-      deep: true,
-    },
+      deep: true
+    }
   },
   apollo: {
     headers: {
@@ -355,7 +355,7 @@ export default {
       `,
       update(data) {
         return data.customertable_headers.headers;
-      },
+      }
     },
     customerList: {
       query: gql`
@@ -382,20 +382,20 @@ export default {
       `,
       variables() {
         return {
-          filter: this.filter,
+          filter: this.filter
         };
       },
       update: data => {
         return {
           customers: data.list_customers.items,
-          total: data.list_customers.total,
+          total: data.list_customers.total
         };
       },
       skip() {
         return !this.filter || this.headers.length === 0;
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>
 

--- a/src/screens/CustomerDetail.vue
+++ b/src/screens/CustomerDetail.vue
@@ -225,7 +225,7 @@ export default {
     ActionLog,
     MemoInput,
     TagDetailCard,
-    MapContainer,
+    MapContainer
   },
   props: ["id"],
   data() {
@@ -235,7 +235,7 @@ export default {
         desc: "",
         subtitle: "",
         tag: "",
-        backUrl: { name: "customers" },
+        backUrl: { name: "customers" }
       },
       pageIcon: this.$t("icon.customer_icon"),
       backBtnContent: this.$t("page_header.customer_mgmt"),
@@ -254,7 +254,7 @@ export default {
       postalHistoriesLoading: this.checkAndShowLoading(),
       contactsForests: [],
       contactsForestsLoading: this.checkAndShowLoading(),
-      echoedForest: null,
+      echoedForest: null
     };
   },
 
@@ -268,13 +268,13 @@ export default {
       info = {
         title: this.$t("page_header.customer_new"),
         subTitle: "",
-        backUrl: "/customers",
+        backUrl: "/customers"
       };
     } else {
       info = {
         title: this.$t("page_header.customer_mgmt"),
         subTitle: "",
-        backUrl: "/customers",
+        backUrl: "/customers"
       };
     }
 
@@ -289,7 +289,7 @@ export default {
       }
       try {
         const customer = await this.$rest.get("/customers/by-business-id", {
-          params: { business_id: this.id },
+          params: { business_id: this.id }
         });
         if (customer && customer.business_id && customer.id) {
           this.customer = customer;
@@ -369,14 +369,14 @@ export default {
     async fetchPostalHistories() {
       this.postalHistoriesLoading = true;
       this.postalHistories = await this.$rest.get(
-        `/customers/${this.pk}/postal-histories`,
+        `/customers/${this.pk}/postal-histories`
       );
       this.postalHistoriesLoading = false;
     },
     async fetchContactsForests() {
       this.contactsForestsLoading = true;
       this.contactsForests = await this.$rest.get(
-        `/customers/${this.pk}/contacts-forests`,
+        `/customers/${this.pk}/contacts-forests`
       );
       this.contactsForestsLoading = false;
     },
@@ -396,7 +396,7 @@ export default {
 
     setSelectedFeatureFromTable(val) {
       this.echoedForest = val;
-    },
+    }
   },
 
   computed: {
@@ -412,18 +412,18 @@ export default {
       if (!this.selectingForestCustomerId)
         return filter(this.contacts, c => c.forestcustomer_id);
       return filter(this.contacts, {
-        forestcustomer_id: this.selectingForestCustomerId,
+        forestcustomer_id: this.selectingForestCustomerId
       });
     },
 
     familyContacts() {
       return filter(this.contacts, {
-        cc_attrs: { contact_type: "FAMILY" },
+        cc_attrs: { contact_type: "FAMILY" }
       });
     },
     otherContacts() {
       return filter(this.contacts, {
-        cc_attrs: { contact_type: "OTHERS" },
+        cc_attrs: { contact_type: "OTHERS" }
       });
     },
     selfContactFormData() {
@@ -439,7 +439,7 @@ export default {
         municipality: this.customer?.self_contact.address.municipality || "",
         telephone: this.customer?.self_contact.telephone || "",
         mobilephone: this.customer?.self_contact.mobilephone || "",
-        email: this.customer?.self_contact.email || "",
+        email: this.customer?.self_contact.email || ""
       };
     },
     bankingInfoFormData() {
@@ -449,22 +449,22 @@ export default {
         branch_name: this.customer?.banking?.branch_name || "",
         account_type: this.customer?.banking?.account_type || "",
         account_number: this.customer?.banking?.account_number || "",
-        account_name: this.customer?.banking?.account_name || "",
+        account_name: this.customer?.banking?.account_name || ""
       };
     },
     basicInfo() {
       return [
         {
           label: this.$t("forms.labels.customer.fullname_kanji"),
-          value: this.getPersonFullname(this.customer?.self_contact.name_kanji),
+          value: this.getPersonFullname(this.customer?.self_contact.name_kanji)
         },
         {
           label: this.$t("forms.labels.customer.fullname_kana"),
-          value: this.getPersonFullname(this.customer?.self_contact.name_kana),
+          value: this.getPersonFullname(this.customer?.self_contact.name_kana)
         },
         {
           label: this.$t("forms.labels.customer.postal_code"),
-          value: this.customer?.self_contact.postal_code || "",
+          value: this.customer?.self_contact.postal_code || ""
         },
         {
           label: this.$t("forms.labels.address"),
@@ -473,20 +473,20 @@ export default {
             " " +
             (this.customer?.self_contact.address.municipality || "") +
             " " +
-            (this.customer?.self_contact.address.sector || ""),
+            (this.customer?.self_contact.address.sector || "")
         },
         {
           label: this.$t("forms.labels.customer.phone_number"),
-          value: this.customer?.self_contact.telephone || "",
+          value: this.customer?.self_contact.telephone || ""
         },
         {
           label: this.$t("forms.labels.customer.mobile_number"),
-          value: this.customer?.self_contact.mobilephone || "",
+          value: this.customer?.self_contact.mobilephone || ""
         },
         {
           label: this.$t("forms.labels.email"),
-          value: this.customer?.self_contact.email || "",
-        },
+          value: this.customer?.self_contact.email || ""
+        }
       ];
     },
 
@@ -494,28 +494,28 @@ export default {
       return [
         {
           label: "口座指定者",
-          value: this.customer?.banking?.account_designator || "",
+          value: this.customer?.banking?.account_designator || ""
         },
         {
           label: "銀行名",
-          value: this.customer?.banking?.bank_name || "",
+          value: this.customer?.banking?.bank_name || ""
         },
         {
           label: "支店名",
-          value: this.customer?.banking?.branch_name || "",
+          value: this.customer?.banking?.branch_name || ""
         },
         {
           label: "預金種類",
-          value: this.customer?.banking?.account_type || "",
+          value: this.customer?.banking?.account_type || ""
         },
         {
           label: "口座番号",
-          value: this.customer?.banking?.account_number || "",
+          value: this.customer?.banking?.account_number || ""
         },
         {
           label: "口座名義",
-          value: this.customer?.banking?.account_name || "",
-        },
+          value: this.customer?.banking?.account_name || ""
+        }
       ];
     },
     selectingForestCustomerId() {
@@ -525,7 +525,7 @@ export default {
     taggedForests() {
       if (this.forests.length === 0) return [];
       return this.forests.filter(f => some(Object.values(f.tags), Boolean));
-    },
+    }
   },
 
   watch: {
@@ -537,9 +537,9 @@ export default {
           ...this.headerInfo,
           title: this.getPersonFullname(this.customer?.self_contact.name_kanji),
           desc: this.customer.business_id,
-          tags: tags_to_array(this.customer?.tags),
+          tags: tags_to_array(this.customer?.tags)
         };
-      },
+      }
     },
     forests: {
       deep: true,
@@ -547,9 +547,9 @@ export default {
         this.headerInfo = {
           ...this.headerInfo,
           subTitle: `${(this.forests && this.forests.length) ||
-            0}件の森林を所有`,
+            0}件の森林を所有`
         };
-      },
+      }
     },
     headerInfo: {
       deep: true,
@@ -557,9 +557,9 @@ export default {
         if (this.headerInfo.title && this.headerInfo.subTitle) {
           this.$store.dispatch("setHeaderInfo", this.headerInfo);
         }
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>
 

--- a/src/screens/Forest.vue
+++ b/src/screens/Forest.vue
@@ -9,7 +9,7 @@
                 'admin',
                 'group_admin',
                 'group_normal_user',
-                'manage_forest',
+                'manage_forest'
               ]"
               icon="mdi-upload"
               :content="
@@ -26,7 +26,7 @@
                 'admin',
                 'group_admin',
                 'group_normal_user',
-                'manage_forest',
+                'manage_forest'
               ]"
               ref="csvUploadInput"
               type="file"
@@ -41,7 +41,7 @@
                 'admin',
                 'group_admin',
                 'group_normal_user',
-                'manage_forest',
+                'manage_forest'
               ]"
             >
               <template v-slot:activator="{ on }">
@@ -94,7 +94,7 @@
             'admin',
             'group_admin',
             'group_normal_user',
-            'manage_forest',
+            'manage_forest'
           ]"
           ref="actionRef"
           :actions="actions"
@@ -176,7 +176,7 @@ export default {
     PageHeader,
     OutlineRoundBtn,
     UpdateActionsDialog,
-    MapContainer,
+    MapContainer
   },
 
   data() {
@@ -184,20 +184,20 @@ export default {
       actions: [
         {
           text: this.$t("action.contract_status_to_contracted"),
-          value: 0,
+          value: 0
         },
         {
           text: this.$t("action.contract_status_to_unsigned"),
-          value: 1,
+          value: 1
         },
         {
           text: this.$t("action.contract_status_to_expired"),
-          value: 2,
+          value: 2
         },
         {
           text: this.$t("action.change_tag_value"),
-          value: 3,
-        },
+          value: 3
+        }
       ],
       pageIcon: this.$t("icon.forest_icon"),
       pageHeader: this.$t("page_header.forest_mgmt"),
@@ -215,7 +215,7 @@ export default {
       uploadCsvLoading: false,
       contractTypes: [],
       bulkUpdateLoading: false,
-      forestsForMap: null,
+      forestsForMap: null
     };
   },
 
@@ -230,20 +230,20 @@ export default {
       `,
       update(data) {
         return data.foresttable_headers.headers;
-      },
+      }
     },
     forestsInfo: {
       query: GetForestList,
       update: data => data.list_forests,
       variables() {
         return {
-          filter: this.filter,
+          filter: this.filter
         };
       },
       skip() {
         return !this.filter || this.headers.length === 0;
-      },
-    },
+      }
+    }
   },
   beforeRouteLeave(to, from, next) {
     if (this.uploadCsvLoading && !confirm(this.$t("messages.confirm_leave")))
@@ -307,7 +307,7 @@ export default {
         formData.append("file", this.$refs.csvUploadInput.files[0]);
         try {
           await this.$rest.post("/forests/upload-csv", formData, {
-            headers: { "Content-Type": "multipart/form-data" },
+            headers: { "Content-Type": "multipart/form-data" }
           });
           this.$apollo.queries.forestsInfo.refetch();
           this.$dialog.notify.success(this.$t("messages.upload_successfully"));
@@ -319,7 +319,7 @@ export default {
           ) {
             this.$dialog.show(ErrorCard, {
               line: error.response.data.line,
-              errors: error.response.data.errors,
+              errors: error.response.data.errors
             });
           }
         } finally {
@@ -337,7 +337,7 @@ export default {
       try {
         this.downloadCsvLoading = true;
         let csvData = await this.$rest.get("/forests/download-csv", {
-          responseType: "blob",
+          responseType: "blob"
         });
         const blob = new Blob([csvData], { type: "text/csv;charset=UTF-8" });
         saveAs(blob, "all-forests.csv");
@@ -354,8 +354,8 @@ export default {
           "/forests/download-csv",
           this.selectedRowIds,
           {
-            responseType: "blob",
-          },
+            responseType: "blob"
+          }
         );
         const blob = new Blob([csvData], { type: "text/csv;charset=UTF-8" });
         saveAs(blob, "selected_forests.csv");
@@ -369,7 +369,7 @@ export default {
       const names = _get(
         data,
         `attributes.customer_cache.repr_name_${nameType}`,
-        "",
+        ""
       );
       const nameList = names.split(",");
       const itemCount = nameList.length;
@@ -380,7 +380,7 @@ export default {
           results +=
             " " +
             this.$t(`tables.another_item_human_${nameType}`, {
-              count: itemCount - 1,
+              count: itemCount - 1
             });
         }
         return results;
@@ -392,7 +392,7 @@ export default {
       const params = {
         ids: this.selectedRowIds,
         key: this.selectedTagForUpdate,
-        value: this.newTagValue,
+        value: this.newTagValue
       };
       try {
         this.updatingTags = true;
@@ -409,7 +409,7 @@ export default {
     },
     async updateContractStatus(status) {
       const ok = confirm(
-        `選択した森林の契約ステータスを${status}に変更しますか？`,
+        `選択した森林の契約ステータスを${status}に変更しますか？`
       );
       if (!ok) return;
       this.bulkUpdateLoading = true;
@@ -417,7 +417,7 @@ export default {
       try {
         await this.$rest.put("/forests/contracts/status", {
           pks: ids,
-          status: status,
+          status: status
         });
       } catch {}
       this.bulkUpdateLoading = false;
@@ -443,7 +443,7 @@ export default {
         default:
           return;
       }
-    },
+    }
   },
 
   watch: {
@@ -456,17 +456,17 @@ export default {
           page,
           itemsPerPage,
           preItemsPerPage: old.itemsPerPage || null,
-          filters: this.requestFilters,
+          filters: this.requestFilters
         };
       },
-      deep: true,
+      deep: true
     },
 
     forestsInfo: {
       handler() {
         this.forestsForMap = this.forestsInfo.forests;
-      },
-    },
+      }
+    }
   },
 
   computed: {
@@ -490,7 +490,7 @@ export default {
             land_attributes__地番支番: element.land_attributes["地番支番"],
             owner__name_kanji: this.renderCustomers(element, "kanji"),
             owner__name_kana: this.renderCustomers(element, "kana"),
-            tags: tags,
+            tags: tags
           };
           if (contracts) {
             item = { ...item, ...contracts };
@@ -518,8 +518,8 @@ export default {
       return this.headers
         .map(h => ({ text: h.text, value: h.filter_name }))
         .filter(f => f.value !== undefined);
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/ForestDetail.vue
+++ b/src/screens/ForestDetail.vue
@@ -149,10 +149,10 @@ export default {
     ForestBasicInfoContainer,
     AttachmentContainer,
     ForestContactTabContainer,
-    MapContainer,
+    MapContainer
   },
   props: {
-    id: String,
+    id: String
   },
   data() {
     return {
@@ -160,14 +160,14 @@ export default {
       pageIcon: this.$t("icon.forest_icon"),
       backBtnContent: this.$t("page_header.forest_mgmt"),
       headerTagColor: "#FFC83B",
-      forestDetailMapInfo: null,
+      forestDetailMapInfo: null
     };
   },
   created() {
     this.$store.dispatch("forest/getForest", this.id).then(() => {
       this.$store.dispatch(
         "setHeaderInfo",
-        this.$store.getters["forest/headerInfo"],
+        this.$store.getters["forest/headerInfo"]
       );
       this.forestDetailMapInfo = this.$store.state.forest.forest;
     });
@@ -181,7 +181,7 @@ export default {
       this.$store.dispatch("forest/getForest", this.id).then(() => {
         this.$store.dispatch(
           "setHeaderInfo",
-          this.$store.getters["forest/headerInfo"],
+          this.$store.getters["forest/headerInfo"]
         );
       });
       this.$store.dispatch("forest/getCustomers", this.id);
@@ -194,9 +194,9 @@ export default {
       await this.$store.dispatch("forest/getForest", this.id);
       this.$store.dispatch(
         "setHeaderInfo",
-        this.$store.getters["forest/headerInfo"],
+        this.$store.getters["forest/headerInfo"]
       );
-    },
+    }
   },
   computed: {
     forestInfo: {
@@ -205,7 +205,7 @@ export default {
       },
       set(val) {
         this.$store.commit("forest/setForest", val);
-      },
+      }
     },
 
     headerData() {
@@ -218,20 +218,20 @@ export default {
           attr && [
             {
               name: "地番面積_ha",
-              data: attr["地番面積_ha"],
+              data: attr["地番面積_ha"]
             },
             {
               name: "面積_ha",
-              data: attr["面積_ha"],
+              data: attr["面積_ha"]
             },
             {
               name: "面積_m2",
-              data: attr["面積_m2"],
+              data: attr["面積_m2"]
             },
             {
               name: "平均傾斜度",
-              data: attr["平均傾斜度"],
-            },
+              data: attr["平均傾斜度"]
+            }
           ]
         );
       }
@@ -249,104 +249,104 @@ export default {
             unit: "",
             first_area: attr["第1林相ID"],
             second_area: attr["第2林相ID"],
-            third_area: attr["第3林相ID"],
+            third_area: attr["第3林相ID"]
           },
           {
             area: "林相名",
             unit: "ha",
             first_area: attr["第1林相名"],
             second_area: attr["第2林相名"],
-            third_area: attr["第3林相名"],
+            third_area: attr["第3林相名"]
           },
           {
             area: "Area",
             unit: "",
             first_area: attr["第1Area"],
             second_area: attr["第2Area"],
-            third_area: attr["第3Area"],
+            third_area: attr["第3Area"]
           },
           {
             area: "面積_ha",
             unit: "",
             first_area: attr["第1面積_ha"],
             second_area: attr["第2面積_ha"],
-            third_area: attr["第3面積_ha"],
+            third_area: attr["第3面積_ha"]
           },
           {
             area: "立木本",
             unit: "",
             first_area: attr["第1立木本"],
             second_area: attr["第2立木本"],
-            third_area: attr["第3立木本"],
+            third_area: attr["第3立木本"]
           },
           {
             area: "立木密",
             unit: "本/ha",
             first_area: attr["第1立木密"],
             second_area: attr["第2立木密"],
-            third_area: attr["第3立木密"],
+            third_area: attr["第3立木密"]
           },
           {
             area: "平均樹",
             unit: "m",
             first_area: attr["第1平均樹"],
             second_area: attr["第2平均樹"],
-            third_area: attr["第3平均樹"],
+            third_area: attr["第3平均樹"]
           },
           {
             area: "樹冠長 ",
             unit: "%",
             first_area: attr["第1樹冠長"],
             second_area: attr["第2樹冠長"],
-            third_area: attr["第3樹冠長"],
+            third_area: attr["第3樹冠長"]
           },
           {
             area: "平均DBH",
             unit: "cm",
             first_area: attr["第1平均DBH"],
             second_area: attr["第2平均DBH"],
-            third_area: attr["第3平均DBH"],
+            third_area: attr["第3平均DBH"]
           },
           {
             area: "合計材",
             unit: "m2",
             first_area: attr["第1合計材"],
             second_area: attr["第2合計材"],
-            third_area: attr["第3合計材"],
+            third_area: attr["第3合計材"]
           },
           {
             area: "ha材積 ",
             unit: "m2/ha",
             first_area: attr["第1ha材積"],
             second_area: attr["第2ha材積"],
-            third_area: attr["第3ha材積"],
+            third_area: attr["第3ha材積"]
           },
           {
             area: "収量比",
             unit: "",
             first_area: attr["第1収量比"],
             second_area: attr["第2収量比"],
-            third_area: attr["第3収量比"],
+            third_area: attr["第3収量比"]
           },
           {
             area: "相対幹",
             unit: "",
             first_area: attr["第1相対幹"],
             second_area: attr["第2相対幹"],
-            third_area: attr["第3相対幹"],
+            third_area: attr["第3相対幹"]
           },
           {
             area: "形状比",
             unit: "%",
             first_area: attr["第1形状比"],
             second_area: attr["第2形状比"],
-            third_area: attr["第3形状比"],
-          },
+            third_area: attr["第3形状比"]
+          }
         ];
       }
       return attributes;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/PostalHistory/PostalHistory.vue
+++ b/src/screens/PostalHistory/PostalHistory.vue
@@ -79,7 +79,7 @@ export default {
     PageHeader,
     OutlineRoundBtn,
     TableAction,
-    UpdateActionsDialog,
+    UpdateActionsDialog
   },
 
   data() {
@@ -87,8 +87,8 @@ export default {
       actions: [
         {
           text: this.$t("action.change_tag_value"),
-          value: 0,
-        },
+          value: 0
+        }
       ],
       pageIcon: "mdi-email-send-outline",
       pageHeader: this.$t("page_header.postalhistory_list"),
@@ -102,7 +102,7 @@ export default {
       filterQueryString: "",
       options: {},
       headers: [],
-      newTagValue: null,
+      newTagValue: null
     };
   },
 
@@ -117,7 +117,7 @@ export default {
   computed: {
     searchCriteria() {
       return this.headers.filter(h => h.text);
-    },
+    }
   },
 
   methods: {
@@ -130,7 +130,7 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
@@ -146,7 +146,7 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
@@ -179,7 +179,7 @@ export default {
         }
         return {
           criteria,
-          keyword,
+          keyword
         };
       });
       this.filterQueryString = this.arrayToQueryString(filter);
@@ -212,7 +212,7 @@ export default {
         their_participants: this.renderParticipants(data),
         our_participants: this.renderUsers(data),
         associated_forest: this.renderForests(data),
-        tags: data.tags,
+        tags: data.tags
       }));
     },
 
@@ -237,7 +237,7 @@ export default {
       const params = {
         ids: this.selectedRowIds,
         key: this.selectedTagForUpdate,
-        value: this.newTagValue,
+        value: this.newTagValue
       };
       try {
         this.updatingTags = true;
@@ -264,8 +264,8 @@ export default {
         default:
           return;
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/PostalHistory/PostalHistoryDetail.vue
+++ b/src/screens/PostalHistory/PostalHistoryDetail.vue
@@ -107,7 +107,7 @@ export default {
     PostalHistoryRelatedUserContainer,
     PostalHistoryOtherRelatedUsersContainer,
     TagDetailCard,
-    ActionLog,
+    ActionLog
   },
 
   data() {
@@ -119,10 +119,10 @@ export default {
       headerInfo: {
         title: this.$t("page_header.postalhistory_new"),
         subTitle: "",
-        backUrl: "/postal-histories",
+        backUrl: "/postal-histories"
       },
       participants: [],
-      participantsLoading: false,
+      participantsLoading: false
     };
   },
   created() {
@@ -145,7 +145,7 @@ export default {
         this.$rest.post(
           `/cache/postal-histories/${this.id}`,
           {},
-          { no_activity: true },
+          { no_activity: true }
         );
       } catch {
         //ignore
@@ -155,7 +155,7 @@ export default {
       this.participantsLoading = true;
       try {
         this.participants = await this.$rest.get(
-          `/postal-histories/${this.id}/customers`,
+          `/postal-histories/${this.id}/customers`
         );
       } catch (error) {}
       this.participantsLoading = false;
@@ -169,7 +169,7 @@ export default {
           results +=
             " " +
             this.$t("tables.another_item_human_kanji", {
-              count: list.length - 1,
+              count: list.length - 1
             });
         }
         return results;
@@ -184,9 +184,9 @@ export default {
           " " +
           this.renderParticipants(this.archive),
         backUrl: "/postal-histories",
-        tags: this.archive.tags,
+        tags: this.archive.tags
       });
-    },
+    }
   },
   computed: {
     id() {
@@ -207,7 +207,7 @@ export default {
       )
         return false;
       return true;
-    },
+    }
   },
   watch: {
     archive: {
@@ -215,9 +215,9 @@ export default {
       handler() {
         this.archiveTags = this.archive.tags;
         this.setHeaderInfo();
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>
 

--- a/src/screens/PostalHistory/PostalHistoryDocumentContainer.vue
+++ b/src/screens/PostalHistory/PostalHistoryDocumentContainer.vue
@@ -112,7 +112,7 @@ export default {
     ContentHeader,
     DocumentCard,
     UpdateButton,
-    AdditionButton,
+    AdditionButton
   },
 
   data() {
@@ -129,7 +129,7 @@ export default {
       duplicateUploadFiles: [],
       invalidUploadFilesExtension: [],
       acceptFileExtensions:
-        ".xlsx, .xls, .csv, .doc, .docx, .pdf, .zip, .png, .jpg, .gif, .bmp, .tif, .txt",
+        ".xlsx, .xls, .csv, .doc, .docx, .pdf, .zip, .png, .jpg, .gif, .bmp, .tif, .txt"
     };
   },
 
@@ -152,7 +152,7 @@ export default {
     async fetchAttachments() {
       this.loading = true;
       const attachments = await this.$rest(
-        `/postal-histories/${this.id}/attachments`,
+        `/postal-histories/${this.id}/attachments`
       );
       if (attachments) {
         this.loading = false;
@@ -189,7 +189,7 @@ export default {
       return intersectionWith(
         files1,
         files2,
-        (f1, f2) => (f1.attributes?.original_file_name || f1.name) === f2.name,
+        (f1, f2) => (f1.attributes?.original_file_name || f1.name) === f2.name
       );
     },
 
@@ -220,11 +220,11 @@ export default {
       const originalDocs = [...this.documents, ...validFiles];
       this.duplicateUploadFiles = this.getDuplicateFiles(
         this.documents,
-        validFiles,
+        validFiles
       );
       const filteredDocs = this.removeDuplicateFiles(
         this.documents,
-        validFiles,
+        validFiles
       );
       if (
         originalDocs.length !== filteredDocs.length ||
@@ -254,20 +254,20 @@ export default {
         if (newDocs.length > 0) {
           const newDocuments = await this.$rest.post(
             `postal-histories/${this.id}/attachments`,
-            data,
+            data
           );
           if (newDocuments) {
             this.documents.splice(
               this.documents.length - 1 - (newDocs.length - 1),
               newDocs.length,
-              ...newDocuments.data,
+              ...newDocuments.data
             );
           }
         }
         if (this.deleteDocuments.length > 0) {
           this.deleteDocuments.forEach(doc => {
             this.$rest.delete(
-              `/postal-histories/${this.id}/attachments/${doc.id}`,
+              `/postal-histories/${this.id}/attachments/${doc.id}`
             );
           });
         }
@@ -281,7 +281,7 @@ export default {
     handleUndoDelete(doc, index) {
       this.$set(doc, "deleted", false);
       this.deleteDocuments.splice(index, 1);
-    },
+    }
   },
 
   computed: {
@@ -289,7 +289,7 @@ export default {
       return (
         this.documents.filter(doc => doc.added || doc.deleted).length === 0
       );
-    },
+    }
   },
 
   watch: {
@@ -299,8 +299,8 @@ export default {
         this.invalidUploadFilesExtension = [];
         this.$refs.fileInput.value = "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/PostalHistory/PostalHistoryInfo.vue
+++ b/src/screens/PostalHistory/PostalHistoryInfo.vue
@@ -81,20 +81,20 @@ export default {
     ArchiveParticipantCard,
     SingleDatePicker,
     TimePicker,
-    ValidationObserver,
+    ValidationObserver
   },
 
   props: {
     info: Object,
     isUpdate: Boolean,
     isSave: Boolean,
-    isDetail: Boolean,
+    isDetail: Boolean
   },
 
   data() {
     return {
       innerDate: "",
-      innerTime: "",
+      innerTime: ""
     };
   },
 
@@ -121,7 +121,7 @@ export default {
 
     datetimePickerInvalid() {
       return !this.date || !this.time;
-    },
+    }
   },
 
   watch: {
@@ -130,7 +130,7 @@ export default {
       async handler() {
         const isValid = await this.$refs.observer.validate();
         this.$emit("archive:save-disable", !isValid);
-      },
+      }
     },
 
     innerDate(val) {
@@ -153,8 +153,8 @@ export default {
         this.info.archive_date = `${date} ${time}`;
         this.$emit("archive:update-basic-info", this.info);
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/PostalHistory/PostalHistoryInfoContainer.vue
+++ b/src/screens/PostalHistory/PostalHistoryInfoContainer.vue
@@ -54,15 +54,15 @@ export default {
   components: {
     ContentHeader,
     PostalHistoryInfo,
-    UpdateButton,
+    UpdateButton
   },
 
   props: {
     isDetail: {
       type: Boolean,
-      default: true,
+      default: true
     },
-    id: String,
+    id: String
   },
 
   data() {
@@ -74,7 +74,7 @@ export default {
       updateLoading: false,
       saveDisabled: false,
       info: {},
-      immutableInfo: {},
+      immutableInfo: {}
     };
   },
 
@@ -108,7 +108,7 @@ export default {
         content: basicInfo.content,
         title: basicInfo.title,
         attributes: basicInfo.attributes,
-        tags: basicInfo.tags,
+        tags: basicInfo.tags
       };
     },
 
@@ -158,10 +158,10 @@ export default {
             this.isSave = false;
           });
       }
-    },
+    }
   },
   watch: {
-    $route: "fetchBasicInfo",
-  },
+    $route: "fetchBasicInfo"
+  }
 };
 </script>

--- a/src/screens/PostalHistory/PostalHistoryOtherRelatedUsersContainer.vue
+++ b/src/screens/PostalHistory/PostalHistoryOtherRelatedUsersContainer.vue
@@ -44,17 +44,17 @@ export default {
   components: {
     ContentHeader,
     UpdateButton,
-    TextInput,
+    TextInput
   },
   props: {
-    archive: { type: Object },
+    archive: { type: Object }
   },
   data() {
     return {
       loading: false,
       id: this.$route.params.id,
       tempParticipants: [],
-      participants: [],
+      participants: []
     };
   },
 
@@ -69,13 +69,13 @@ export default {
       this.loading = true;
       try {
         await this.$rest.put(`postal-histories/${this.id}/other-participants`, {
-          other_participants: this.tempParticipants,
+          other_participants: this.tempParticipants
         });
         this.participants = this.tempParticipants;
         this.isEditing = false;
       } catch (error) {}
       this.loading = false;
-    },
+    }
   },
 
   computed: {
@@ -85,11 +85,11 @@ export default {
       },
       set(val) {
         this.tempParticipants = reject(val.split(","), isEmpty);
-      },
+      }
     },
     saveDisabled() {
       return this.participantsText === this.participants.join(",");
-    },
+    }
   },
 
   watch: {
@@ -103,8 +103,8 @@ export default {
         ? this.archive.attributes.other_participants || []
         : [];
       this.tempParticipants = [...this.participants];
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/PostalHistory/PostalHistoryParticipantContainer.vue
+++ b/src/screens/PostalHistory/PostalHistoryParticipantContainer.vue
@@ -101,11 +101,11 @@ export default {
     AdditionButton,
     SelectListModal,
     CustomerContactList,
-    CustomerContactCard,
+    CustomerContactCard
   },
   props: {
     id: { type: String },
-    participants: { type: Array, default: () => [] },
+    participants: { type: Array, default: () => [] }
   },
   data() {
     return {
@@ -114,7 +114,7 @@ export default {
       selectingContactId: null,
       selectingCustomerId: null,
       customerIdNameMap: {},
-      itemsForAddingUrl: "/customercontacts",
+      itemsForAddingUrl: "/customercontacts"
     };
   },
   computed: {
@@ -129,20 +129,20 @@ export default {
     contactsToAddData() {
       return this.contactsToAdd.map(c => ({
         contact_id: c.id,
-        customer_id: c.customer_id,
+        customer_id: c.customer_id
       }));
     },
     contactsToDeleteData() {
       return this.contactsToDelete.map(c => ({
         contact_id: c.id,
-        customer_id: c.customer_id,
+        customer_id: c.customer_id
       }));
     },
     contactIdsMap() {
       return Object.fromEntries(
-        this.tempParticipants.map(c => [`${c.id},${c.customer_id}`, true]),
+        this.tempParticipants.map(c => [`${c.id},${c.customer_id}`, true])
       );
-    },
+    }
   },
   methods: {
     renderCustomerName(item) {
@@ -171,7 +171,7 @@ export default {
         this.saving = true;
         await this.$rest.put(`/postal-histories/${this.id}/customers`, {
           added: this.contactsToAddData,
-          deleted: this.contactsToDeleteData,
+          deleted: this.contactsToDeleteData
         });
         this.$emit("saved");
         this.saving = false;
@@ -185,12 +185,12 @@ export default {
     async handleAdd() {
       const item = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       this.$set(
         this.customerIdNameMap,
         item.customer_id,
-        item.customer_name_kanji,
+        item.customer_name_kanji
       );
       item.added = true;
       if (this.selectingCustomerId) {
@@ -209,7 +209,7 @@ export default {
         delete contact.added;
         this.contactsToAdd = reject(this.contactsToAdd, {
           id: contact.id,
-          customer_id: contact.customer_id,
+          customer_id: contact.customer_id
         });
         this.itemsForAdding = { results: [] };
       } else {
@@ -221,9 +221,9 @@ export default {
       this.$set(contact, "deleted", undefined);
       this.contactsToDelete = reject(this.contactsToDelete, {
         id: contact.id,
-        customer_id: contact.customer_id,
+        customer_id: contact.customer_id
       });
-    },
+    }
   },
   watch: {
     isEditing(val) {
@@ -247,7 +247,7 @@ export default {
         customerIdNameMap[c.customer_id] = c.customer_name_kanji;
       }
       this.customerIdNameMap = customerIdNameMap;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/screens/PostalHistory/PostalHistoryRelatedForestContainer.vue
+++ b/src/screens/PostalHistory/PostalHistoryRelatedForestContainer.vue
@@ -92,7 +92,7 @@ export default {
     UpdateButton,
     AdditionButton,
     SelectListModal,
-    ForestInfoCard,
+    ForestInfoCard
   },
 
   data() {
@@ -111,7 +111,7 @@ export default {
       selectingForestIndex: null,
       addRelatedForestLoading: false,
       searchNext: null,
-      showNotFoundMsg: false,
+      showNotFoundMsg: false
     };
   },
 
@@ -170,14 +170,14 @@ export default {
         const isDeleted = await this.$rest.delete(
           `/postal-histories/${this.id}/forests`,
           {
-            data: deleteRequest,
-          },
+            data: deleteRequest
+          }
         );
         if (isDeleted) {
           this.selectingForestId = null;
           this.relatedForests = this.removeDuplicateForests(
             this.relatedForests,
-            this.deletedForests,
+            this.deletedForests
           );
           const pureForests = cloneDeep(this.deletedForests);
           pureForests.forEach(f => (f.deleted = false));
@@ -193,16 +193,16 @@ export default {
         const addRequest = { ids: addedIds };
         const newRelatedForests = await this.$rest.post(
           `/postal-histories/${this.id}/forests`,
-          addRequest,
+          addRequest
         );
         if (newRelatedForests) {
           const tempForest = this.removeDuplicateForests(
             this.relatedForests,
-            newRelatedForests.data,
+            newRelatedForests.data
           );
           this.allForests = this.removeDuplicateForests(
             this.allForests,
-            this.addedForests,
+            this.addedForests
           );
           this.immutableAllForest = cloneDeep(this.allForests);
           tempForest.push(...newRelatedForests.data);
@@ -231,7 +231,7 @@ export default {
     async fetchRelatedForests() {
       this.loading = true;
       const response = await this.$rest.get(
-        `/postal-histories/${this.id}/forests`,
+        `/postal-histories/${this.id}/forests`
       );
       if (response) {
         this.relatedForests = response.data;
@@ -243,17 +243,17 @@ export default {
       if (this.next !== null) {
         this.fetchAllForestLoading = true;
         const response = await this.$rest.get(
-          next !== "" ? next : "/forests/minimal",
+          next !== "" ? next : "/forests/minimal"
         );
         if (response) {
           this.fetchAllForestLoading = false;
           const filteredForests = this.removeDuplicateForests(
             response.results,
-            this.relatedForests,
+            this.relatedForests
           );
           const allForests = this.removeDuplicateForests(
             filteredForests,
-            this.allForests,
+            this.allForests
           );
           this.allForests.push(...allForests);
           this.immutableAllForest.push(...allForests);
@@ -303,8 +303,8 @@ export default {
       this.fetchAllForestLoading = true;
       const response = await this.$rest.get("/forests/minimal", {
         params: {
-          search: keyword || "",
-        },
+          search: keyword || ""
+        }
       });
       if (response) {
         this.showNotFoundMsg =
@@ -313,14 +313,14 @@ export default {
         this.immutableAllForest = [];
         const tempSearchData = this.removeDuplicateForests(
           response.results,
-          this.relatedForests,
+          this.relatedForests
         );
         this.next = response.next;
         this.allForests.push(...tempSearchData);
         this.immutableAllForest.push(...tempSearchData);
         this.fetchAllForestLoading = false;
       }
-    },
+    }
   },
 
   computed: {
@@ -330,7 +330,7 @@ export default {
 
     deletedForests() {
       return this.relatedForests.filter(forest => forest.deleted);
-    },
+    }
   },
 
   watch: {
@@ -346,8 +346,8 @@ export default {
         if (allForests.length <= 3 && this.next !== null) {
           this.handleLoadMore();
         }
-      },
-    },
-  },
+      }
+    }
+  }
 };
 </script>

--- a/src/screens/PostalHistory/PostalHistoryRelatedUserContainer.vue
+++ b/src/screens/PostalHistory/PostalHistoryRelatedUserContainer.vue
@@ -92,7 +92,7 @@ export default {
     UpdateButton,
     AdditionButton,
     SelectListModal,
-    ArchiveParticipantCard,
+    ArchiveParticipantCard
   },
 
   data() {
@@ -102,7 +102,7 @@ export default {
       addedParticipants: [],
       deletedParticipants: [],
       itemsForAddingUrl: "/users/minimal",
-      isLoading_: false,
+      isLoading_: false
     };
   },
 
@@ -136,9 +136,9 @@ export default {
           `/postal-histories/${this.archive_id}/users`,
           {
             data: {
-              ids: deletedIds,
-            },
-          },
+              ids: deletedIds
+            }
+          }
         );
         if (isDeleted) {
           this.modalSelectingId = null;
@@ -151,7 +151,7 @@ export default {
         const addedIds = this.addedParticipants.map(p => p.id);
         const newParticipants = await this.$rest.post(
           `/postal-histories/${this.archive_id}/users`,
-          { ids: addedIds },
+          { ids: addedIds }
         );
         if (newParticipants) {
         }
@@ -180,7 +180,7 @@ export default {
     submitRelatedParticipant() {
       const participant = this.itemsForAdding.results.splice(
         this.modalSelectingIndex,
-        1,
+        1
       )[0];
       participant.added = true;
       this.addedParticipants.push(participant);
@@ -194,7 +194,7 @@ export default {
       if (participant.added) {
         delete participant.added;
         this.addedParticipants = reject(this.addedParticipants, {
-          id: participant.id,
+          id: participant.id
         });
         this.itemsForAdding = { results: [] };
       } else {
@@ -205,9 +205,9 @@ export default {
     handleUndoDelete(participant) {
       this.$set(participant, "deleted", undefined);
       this.deletedParticipants = reject(this.deletedParticipants, {
-        id: participant.id,
+        id: participant.id
       });
-    },
+    }
   },
 
   computed: {
@@ -216,7 +216,7 @@ export default {
     },
     userIdsMap() {
       return Object.fromEntries(
-        this.tempUserParticipants.map(u => [u.id, true]),
+        this.tempUserParticipants.map(u => [u.id, true])
       );
     },
     saveDisabled() {
@@ -224,7 +224,7 @@ export default {
         this.addedParticipants.length === 0 &&
         this.deletedParticipants.length === 0
       );
-    },
+    }
   },
 
   watch: {
@@ -242,8 +242,8 @@ export default {
           this.itemsForAdding = { results: [] };
         }
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/ScreenMixin.js
+++ b/src/screens/ScreenMixin.js
@@ -6,7 +6,7 @@ export default {
       showChangeTagDialog: false,
       fetchTagsLoading: false,
       updatingTags: false,
-      selectedTagForUpdate: null,
+      selectedTagForUpdate: null
     };
   },
   mounted() {
@@ -41,7 +41,7 @@ export default {
       this.selectedTagForUpdate = null;
       actionListRefChild.reset();
       actionListRef.resizeInputWidth();
-    },
+    }
   },
   computed: {
     requestFilters() {
@@ -49,7 +49,7 @@ export default {
         ? this.$refs.filter.conditions.map(condition => {
             return {
               criteria: condition.criteria,
-              keyword: condition.keyword,
+              keyword: condition.keyword
             };
           })
         : [];
@@ -60,6 +60,6 @@ export default {
         this.tableSelectedRows.length > 0 &&
         this.tableSelectedRows.map(row => row.id)
       );
-    },
-  },
+    }
+  }
 };

--- a/src/screens/Slack/AuthForm.vue
+++ b/src/screens/Slack/AuthForm.vue
@@ -77,22 +77,22 @@ import TextInput from "@/components/forms/TextInput";
 export default {
   components: {
     TextInput,
-    ValidationObserver,
+    ValidationObserver
   },
   props: {
     onSubmit: {
-      type: Function,
-    },
+      type: Function
+    }
   },
   data() {
     return {
       form: {
         email: "",
-        password: "",
+        password: ""
       },
       formError: "",
       loading: false,
-      success: false,
+      success: false
     };
   },
   methods: {
@@ -112,15 +112,15 @@ export default {
       } finally {
         this.loading = false;
       }
-    },
+    }
   },
   watch: {
     success(val) {
       if (val) {
         this.formError = "";
       }
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/Slack/Oauth.vue
+++ b/src/screens/Slack/Oauth.vue
@@ -15,14 +15,14 @@ export default {
     async slackOauth() {
       await this.$rest.post("slack/oauth", {
         ...this.$refs.authForm.form,
-        code: this.code,
+        code: this.code
       });
-    },
+    }
   },
   computed: {
     code() {
       return this.$route.query.code;
-    },
-  },
+    }
+  }
 };
 </script>

--- a/src/screens/UserDetail.vue
+++ b/src/screens/UserDetail.vue
@@ -94,7 +94,7 @@ export default {
     ContentHeader,
     ActionLog,
     ValidationObserver,
-    UpdateButton,
+    UpdateButton
   },
 
   data() {
@@ -111,13 +111,13 @@ export default {
         username: "",
         group: "",
         email: "",
-        is_active: false,
+        is_active: false
       },
       isLoading: false,
       isUpdate: {
-        basicInfo: false,
+        basicInfo: false
       },
-      errors: [],
+      errors: []
     };
   },
 
@@ -133,7 +133,7 @@ export default {
   methods: {
     async getUserPermission(callback) {
       const response = await this.$rest.get(
-        `/users/${this.$route.params.id}/permissions`,
+        `/users/${this.$route.params.id}/permissions`
       );
       if (response) {
         this.userPermissions = response;
@@ -148,7 +148,7 @@ export default {
       if (response) {
         this.groups = response.groups.map(item => ({
           text: item.name,
-          value: item.id,
+          value: item.id
         }));
       }
     },
@@ -180,7 +180,7 @@ export default {
       Object.keys(errors).forEach(errorKey => {
         formatedErrors.push({
           loc: errorKey,
-          message: errors[errorKey].join(", "),
+          message: errors[errorKey].join(", ")
         });
       });
 
@@ -201,7 +201,7 @@ export default {
         this.isLoading = true;
         const response = await this.$rest.put(
           `/users/${this.$route.params.id}`,
-          { ...this.form, is_active: this.form.is_active.value },
+          { ...this.form, is_active: this.form.is_active.value }
         );
         if (response) {
           await this.getUserPermission();
@@ -237,9 +237,9 @@ export default {
         subTitle:
           fromNowText &&
           `${this.$t(
-            "user_management.tables.headers.last_login",
+            "user_management.tables.headers.last_login"
           )} ${fromNowText}`,
-        backUrl: "/users",
+        backUrl: "/users"
       };
 
       this.$store.dispatch("setHeaderInfo", info);
@@ -251,8 +251,7 @@ export default {
 
     copyToForm(basicInfo) {
       Object.keys(this.form).forEach(
-        key =>
-          (this.form[key] = basicInfo.find(item => item.key === key).value),
+        key => (this.form[key] = basicInfo.find(item => item.key === key).value)
       );
     },
 
@@ -261,7 +260,7 @@ export default {
         return (
           this.userPermissions.groups.map(group => ({
             text: group.name,
-            value: group.id,
+            value: group.id
           }))[0] || {}
         );
       }
@@ -279,35 +278,35 @@ export default {
             label: this.$t("user_management.tables.headers.last_name"),
             value: userInfo.last_name,
             rules: "required",
-            name: "user_management.tables.headers.last_name",
+            name: "user_management.tables.headers.last_name"
           },
           {
             key: "first_name",
             label: this.$t("user_management.tables.headers.first_name"),
             value: userInfo.first_name,
             rules: "required",
-            name: "user_management.tables.headers.first_name",
+            name: "user_management.tables.headers.first_name"
           },
           {
             key: "username",
             label: this.$t("user_management.tables.headers.username"),
             value: userInfo.username,
             rules: "required",
-            name: "user_management.tables.headers.username",
+            name: "user_management.tables.headers.username"
           },
           {
             key: "email",
             label: this.$t("user_management.tables.headers.email"),
             value: userInfo.email,
             rules: "required|email",
-            name: "user_management.tables.headers.email",
+            name: "user_management.tables.headers.email"
           },
           {
             key: "group",
             label: this.$t("user_management.tables.headers.roles"),
             value: this.mapUserPermissions(),
             type: "select",
-            items: groups,
+            items: groups
           },
           {
             key: "is_active",
@@ -316,20 +315,20 @@ export default {
               value: userInfo.is_active === true,
               text: userInfo.is_active
                 ? this.$t("enums.user_status.active")
-                : this.$t("enums.user_status.inactive"),
+                : this.$t("enums.user_status.inactive")
             },
             type: "select",
             items: [
               { value: true, text: this.$t("enums.user_status.active") },
-              { value: false, text: this.$t("enums.user_status.inactive") },
-            ],
-          },
+              { value: false, text: this.$t("enums.user_status.inactive") }
+            ]
+          }
         ];
         this.copyToForm(basicInfo);
       }
 
       return basicInfo;
-    },
+    }
   },
 
   computed: {
@@ -339,8 +338,8 @@ export default {
 
     getActionLogs() {
       return actionLogs;
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/screens/UserList.vue
+++ b/src/screens/UserList.vue
@@ -60,7 +60,7 @@ export default {
     PageHeader,
     MainSection,
     CreateUserForm,
-    OutlineRoundBtn,
+    OutlineRoundBtn
   },
   data() {
     return {
@@ -74,7 +74,7 @@ export default {
       results: [],
       isLoading: false,
       options: {},
-      showCreationForm: false,
+      showCreationForm: false
     };
   },
   methods: {
@@ -94,7 +94,7 @@ export default {
         is_active:
           item.is_active === true
             ? this.$t("enums.user_status.active")
-            : this.$t("enums.user_status.inactive"),
+            : this.$t("enums.user_status.inactive")
       }));
     },
 
@@ -108,12 +108,12 @@ export default {
       ) {
         response = await this.$rest.get(
           `/users?page_size=${perPage}&page=${page}&sort_by=${sortBy.join(
-            ",",
-          )}&sort_desc=${sortDesc.join(",")}`,
+            ","
+          )}&sort_desc=${sortDesc.join(",")}`
         );
       } else {
         response = await this.$rest.get(
-          `/users?page_size=${perPage}&page=${page}`,
+          `/users?page_size=${perPage}&page=${page}`
         );
       }
 
@@ -128,12 +128,12 @@ export default {
 
     async onUserCreated() {
       await this.getData(this.filter.preItemsPerPage, this.filter.page);
-    },
+    }
   },
   async mounted() {
     this.$store.dispatch("setHeaderInfo", {
       title: this.$t("page_header.user_mgmt"),
-      subtitle: "",
+      subtitle: ""
     });
   },
 
@@ -147,11 +147,11 @@ export default {
           sortDesc,
           page,
           itemsPerPage,
-          preItemsPerPage: old.itemsPerPage || null,
+          preItemsPerPage: old.itemsPerPage || null
         };
         await this.getData(itemsPerPage, page, sortBy, sortDesc);
-      },
-    },
+      }
+    }
   },
 
   computed: {
@@ -161,47 +161,47 @@ export default {
           text: "",
           align: "center",
           value: "internal_id",
-          sortable: false,
+          sortable: false
         },
         {
           text: this.$t("user_management.tables.headers.username"),
           align: "center",
           value: "username",
-          sortable: false,
+          sortable: false
         },
         {
           text: this.$t("user_management.tables.headers.full_name"),
           align: "center",
           value: "full_name",
-          sortable: false,
+          sortable: false
         },
         {
           text: this.$t("user_management.tables.headers.roles"),
           align: "center",
           value: "roles",
-          sortable: false,
+          sortable: false
         },
         {
           text: this.$t("user_management.tables.headers.email"),
           align: "center",
           value: "email",
-          sortable: false,
+          sortable: false
         },
         {
           text: this.$t("user_management.tables.headers.status"),
           align: "center",
           value: "is_active",
-          sortable: true,
+          sortable: true
         },
         {
           text: this.$t("user_management.tables.headers.last_login"),
           align: "center",
           value: "last_login_text",
-          sortable: false,
-        },
+          sortable: false
+        }
       ];
-    },
-  },
+    }
+  }
 };
 </script>
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,7 +12,7 @@ export default new Vuex.Store({
     headerInfo: {},
     headerTagColor: "transparent",
     backBtnContent: "",
-    inMaintain: false,
+    inMaintain: false
   },
   mutations: {
     setPageHeader(state, pageHeader) {
@@ -35,7 +35,7 @@ export default new Vuex.Store({
     },
     setInMaintain(state, value) {
       state.inMaintain = value;
-    },
+    }
   },
   actions: {
     setPageHeader({ commit }, pageHeader) {
@@ -61,9 +61,9 @@ export default new Vuex.Store({
         const status = await api.getMaintenanceStatus();
         commit("setInMaintain", status.in_maintain);
       } catch {}
-    },
+    }
   },
   modules: {
-    forest,
-  },
+    forest
+  }
 });

--- a/src/store/modules/forest.js
+++ b/src/store/modules/forest.js
@@ -12,7 +12,7 @@ const state = {
   archives: [],
   postalHistories: [],
   archivesLoading: false,
-  postalHistoriesLoading: false,
+  postalHistoriesLoading: false
 };
 
 const getters = {
@@ -23,12 +23,12 @@ const getters = {
       subTitle: getters.owner_repr,
       desc: state.forest.internal_id,
       tags: tags_to_array(state.forest.tags),
-      backUrl: { name: "forests" },
+      backUrl: { name: "forests" }
     };
   },
   owner_repr(state) {
     const names = state.forest.attributes.customer_cache.repr_name_kanji.split(
-      ",",
+      ","
     );
     if (names.length === 0) return "";
     return `${names[0]}${names.length > 1 ? ` 他${names.length - 1}名` : ""}`;
@@ -50,13 +50,13 @@ const getters = {
   customerIdNameMap(state) {
     if (state.customers.length === 0) return {};
     return Object.fromEntries(
-      state.customers.map(c => [c.id, c.self_contact?.name_kanji]),
+      state.customers.map(c => [c.id, c.self_contact?.name_kanji])
     );
   },
   taggedCustomers(state) {
     if (state.customers.length === 0) return [];
     return state.customers.filter(c => some(Object.values(c.tags), Boolean));
-  },
+  }
 };
 
 const actions = {
@@ -95,12 +95,12 @@ const actions = {
   },
   toggleDefaultCustomerContactLocal(
     { commit },
-    { customer_id, contact_id, val },
+    { customer_id, contact_id, val }
   ) {
     commit("toggleDefaultCustomerContactLocal", {
       customer_id,
       contact_id,
-      val,
+      val
     });
   },
   async toggleDefaultCustomer({}, { id, customer_id, val }) {
@@ -111,9 +111,9 @@ const actions = {
       id,
       customer_id,
       contact_id,
-      val,
+      val
     );
-  },
+  }
 };
 
 const mutations = {
@@ -172,11 +172,11 @@ const mutations = {
     const newCustomersContacts = [...state.customersContacts];
     const c = find(newCustomersContacts, {
       id: contact_id,
-      customer_id: customer_id,
+      customer_id: customer_id
     });
     c.default = val;
     state.customersContacts = newCustomersContacts;
-  },
+  }
 };
 
 export default {
@@ -184,5 +184,5 @@ export default {
   state,
   getters,
   actions,
-  mutations,
+  mutations
 };

--- a/vue.config.js
+++ b/vue.config.js
@@ -9,18 +9,18 @@ module.exports = {
       "^/api": {
         target: "http://localhost:8000",
         ws: false,
-        changeOrigin: true,
+        changeOrigin: true
       },
       "^/graphql": {
         target: "http://localhost:8000",
         ws: false,
-        changeOrigin: true,
-      },
+        changeOrigin: true
+      }
     },
     overlay: {
       warnings: false,
-      errors: true,
-    },
+      errors: true
+    }
   },
   configureWebpack: config => {
     if (!config.plugins) config.plugins = [];
@@ -31,7 +31,7 @@ module.exports = {
           algorithm: "gzip",
           test: /\.js$|\.css$|\.html$/,
           exclude: "index.html",
-          minRatio: 0.8,
+          minRatio: 0.8
         }),
         new CompressionPlugin({
           filename: "[path].br[query]",
@@ -40,12 +40,12 @@ module.exports = {
           exclude: "index.html",
           compressionOptions: {
             // zlib’s `level` option matches Brotli’s `BROTLI_PARAM_QUALITY` option.
-            level: 11,
+            level: 11
           },
           threshold: 10240,
           minRatio: 0.8,
-          deleteOriginalAssets: false,
-        }),
+          deleteOriginalAssets: false
+        })
       );
     }
   },
@@ -62,5 +62,5 @@ module.exports = {
       });
     }
   },
-  transpileDependencies: ["vuetify"],
+  transpileDependencies: ["vuetify"]
 };


### PR DESCRIPTION
Signed-off-by: Torgian <nathaniel@georepublic.de>

Changes proposed in this pull request:
- Removed the multiline rule in the config file.


I found that it seemed to conflict with `prettify`. This basically prevented prettify from doing its job ( removing dangling commas ) so the IDE and terminal would always return error messages about commas being in places they shouldn't be. I tested this locally and it fixed 114 files. Commas were the consistent change, as well as some of the usual spacing issues. I tested this further by going through the pages in the app.

Comparison: over 80 seconds to run linter originally, now only takes 18 to 19 seconds on my machine.

@hyakumori/maintainer
