### PR TITLE
Found tha tname was inside the function, rather than outside. Fixed.

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -68,7 +68,7 @@
           <v-radio-group mandatory v-model="layerRadio">
             <v-radio
               v-for="layer of rLayers"
-              :key="String(layer.getProperties(name))"
+              :key="layer.getProperties().name"
               :label="returnLayerLabel(layer.getProperties().id)"
               :value="String(layer.getProperties().id)"
               :name="String(layer.getProperties().id)"


### PR DESCRIPTION
Signed-off-by: Torgian <nathaniel@georepublic.de>

Changes proposed in this pull request:
- `name` property was inside the function call, rather than outside. This PR fixes this.
-
-

@hyakumori/maintainer
