### PR TITLE
Fix auto zoom

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -391,7 +391,7 @@ export default {
         this.$refs.hyakumoriView.$view.fit(
           this.$refs.jsonSource.$source.getExtent(),
           {
-            duration: 1000
+            duration: 50
           }
         );
       }, 100);


### PR DESCRIPTION
Addressed #62 

Changes proposed in this pull request:
- Fix auto zoom to features on a map
- Added function to zoom to feature when it is clicked on the map

The auto-zoom function was initially a watcher ,but this caused problems. Before, when you clicked on a feature after being zoomed in on the map, the map would automatically zoom back out to fit the extent of _all_ the features in the view. 

I replaced this with a method that is called once when the map is mounted. The timeout can be adjusted later if needed. 

**Note** Observe that the fixes in #63 are in this MR as well.
@hyakumori/maintainer
