### PR TITLE
fix typo in environmental variable declaration of geoserver url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       BACKEND_URL: ${{ secrets.BACKEND_URL }}
       VUE_APP_GRAPHQL_HTTP: ${{ secrets.VUE_APP_GRAPHQL_HTTP }}
       VUE_APP_REST_HTTP: ${{ secrets.VUE_APP_REST_HTTP }}
-      VUE_APP_GEOSERVER: $ {{ secrets.VUE_APP_GEOSERVER }}
+      VUE_APP_GEOSERVER: ${{ secrets.VUE_APP_GEOSERVER }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Signed-off-by: Iosefa Percival <ipercival@gmail.com>

Fixes #72 .

Changes proposed in this pull request:
- remove space in declaration of env var using github secret.

@hyakumori/maintainer
