### PR TITLE
Prevent popup from appearing if no layers are visible

### DIFF
--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -512,13 +512,12 @@ export default {
       if (this.$refs.hyakumoriSource) {
         try {
           this.$refs.map.forEachLayerAtPixel(event.pixel, x => {
-            return x
-          })
-        }
-        catch(e) {
-          console.log('No layer here!')
-          this.showCard = false
-          return
+            return x;
+          });
+        } catch (e) {
+          console.log("No layer here!");
+          this.showCard = false;
+          return;
         }
         const loggedURL = this.$refs.hyakumoriSource.getFeatureInfoUrl(
           event.coordinate,


### PR DESCRIPTION
Signed-off-by: Torgian <nathaniel@georepublic.de>

Fixes #75 

Changes proposed in this pull request:
- Adds a try / catch block for detecting layers at clicked pixel.

At first I thought about just detecting specific layers by ID, but this is not very efficient and would need to be updated depending on the type of layers added.

I decided to use forEachLayerAtPixel function. Read about it [here](https://openlayers.org/en/latest/apidoc/module-ol_Map-Map.html#forEachLayerAtPixel)

This function _will_ return an error locally ( a CORS issue ) otherwise, it should return null. That said, I wrapped it in a try / catch block.

The try will return the layer at the clicked pixel if present and run the rest of the code. However, if there are no layers it'll catch that, return a console message, and set `showCard` to false. The latter will close any popup card that may already be open during the click event.

This also has the positive side-effect of closing the card if no layers are present ( such as clicking outside of the WMS layer ). 
@hyakumori/maintainer
