### PR TITLE
Add forest interaction

### DIFF
--- a/src/components/DataList.vue
+++ b/src/components/DataList.vue
@@ -250,6 +250,11 @@ export default {
       const innerHeight = window.innerHeight < 835 ? 835 : window.innerHeight;
       this.tableHeight =
         innerHeight - 270 <= 625 ? innerHeight : innerHeight - 270 - (56 + 16);
+    },
+
+    sendSelectedToMap(val) {
+      console.log(val[0]);
+      this.$emit("showSelectedOntoMap", val[0]);
     }
   },
   beforeUpdate() {
@@ -283,6 +288,7 @@ export default {
 
     selected(newVal, oldVal) {
       if (newVal !== oldVal) {
+        this.sendSelectedToMap(newVal)
         this.$emit("selectedRow", newVal);
       }
     },

--- a/src/components/MapContainer.vue
+++ b/src/components/MapContainer.vue
@@ -207,7 +207,7 @@ export default {
       default: false
     },
 
-    echoedForestIdFromTable: {
+    echoedForestFromTable: {
       type: Object,
       default: null
     }
@@ -333,17 +333,24 @@ export default {
       }
     },
 
-    echoedForestIdFromTable(val, prev) {
+    echoedForestFromTable(val, prev) {
+      console.log(val, "vlaue?");
       const featuresSource = this.vLayers
         .find(l => l.values_.id === "tableLayer")
         .getSource();
+
       const filteredFeature = featuresSource
         .getFeatures()
-        .find(f => f.getId() === val);
-      const prevFilteredFeature = featuresSource
-        .getFeatures()
-        .find(f => f.getId() === prev);
+        .find(f => f.getId() === val.id);
 
+      let prevFilteredFeature = null;
+      if (prev) {
+        prevFilteredFeature = featuresSource
+          .getFeatures()
+          .find(f => f.getId() === prev.id);
+      }
+
+      console.log(filteredFeature);
       if (filteredFeature) {
         const style = new Style({
           stroke: new Stroke({ color: "FFF" }),

--- a/src/screens/Forest.vue
+++ b/src/screens/Forest.vue
@@ -76,7 +76,7 @@
         v-if="forestsInfo"
         class="px-7"
         :forests="forestsForMap"
-        :echoedForestIdFromTable="echoedTableForest"
+        :echoedForestFromTable="echoedTableForest"
         @echoSelectedFeature="setSelectedFeatureFromMap"
         :big="true"
       >
@@ -456,7 +456,7 @@ export default {
     },
 
     setSelectedFeatureFromTable(val) {
-      console.log(this.echoedForest, "echoed forest");
+      console.log(val, "echoed forest");
       this.echoedTableForest = val;
     }
   },


### PR DESCRIPTION
Fixes # .

The latest commit adds map functionality, where clicking on a feature will select that feature in the table ( and selecting a different feature will push that to the table section, allowing multiple selections)

However, I'm having trouble doing the same from the other way around. Selecting a table row to show that feature on the map is not working correctly. I haven't bothered pushing these changes yet.

@hyakumori/maintainer
